### PR TITLE
Parametrized pip_package option.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,10 @@
 #  Default: present
 #  Allowed values: 'absent', 'present', 'latest'
 #
+# [*pip_package*]
+#  Name of the package to install pip with.
+#  Default: undef
+#
 # [*dev*]
 #  Desired installation state for python-dev. Boolean values are deprecated.
 #  Default: absent
@@ -70,6 +74,7 @@ class python (
   $ensure                    = $python::params::ensure,
   $version                   = $python::params::version,
   $pip                       = $python::params::pip,
+  $pip_package               = $python::params::pip_package,
   $dev                       = $python::params::dev,
   $virtualenv                = $python::params::virtualenv,
   $gunicorn                  = $python::params::gunicorn,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -235,6 +235,12 @@ class python::install {
     }
   }
 
+  if $::python::pip_package != undef {
+    Package <| title == 'pip' |> {
+      name => $::python::pip_package
+    }
+  }
+
   if $python::manage_gunicorn {
     $gunicorn_ensure = $python::gunicorn ? {
       true    => 'present',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class python::params {
   $ensure                 = 'present'
   $version                = 'system'
   $pip                    = 'present'
+  $pip_package            = undef
   $dev                    = 'absent'
   $virtualenv             = 'absent'
   $gunicorn               = 'absent'

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -97,6 +97,13 @@ describe 'python', :type => :class do
       end
     end
 
+    describe "with python::pip_package" do
+      context "dummy-package" do
+        let (:params) {{ :pip_package => 'dummy-package' }}
+        it { is_expected.to contain_package("pip").with_name('dummy-package') }
+      end
+    end
+
   end
 
   context "on a Fedora 22 OS" do
@@ -115,6 +122,13 @@ describe 'python', :type => :class do
     describe "EPEL does not exist for Fedora" do
       context "default/empty" do
         it { should_not contain_class('epel') }
+      end
+    end
+
+    describe "with python::pip_package" do
+      context "dummy-package" do
+        let (:params) {{ :pip_package => 'dummy-package' }}
+        it { is_expected.to contain_package("pip").with_name('dummy-package') }
       end
     end
 
@@ -216,6 +230,13 @@ describe 'python', :type => :class do
         it { is_expected.to contain_package("python-dev").with_ensure('absent') }
       end
     end
+
+    describe "with python::pip_package" do
+      context "dummy-package" do
+        let (:params) {{ :pip_package => 'dummy-package' }}
+        it { is_expected.to contain_package("pip").with_name('dummy-package') }
+      end
+    end
   end
 
   context "on a Redhat 6 OS" do
@@ -232,6 +253,13 @@ describe 'python', :type => :class do
     end
     it { is_expected.to contain_class("python::install") }
     it { is_expected.to contain_package("pip").with_name('python-pip') }
+
+    describe "with python::pip_package" do
+      context "dummy-package" do
+        let (:params) {{ :pip_package => 'dummy-package' }}
+        it { is_expected.to contain_package("pip").with_name('dummy-package') }
+      end
+    end
   end
 
   context "on a Redhat 7 OS" do
@@ -248,6 +276,13 @@ describe 'python', :type => :class do
     end
     it { is_expected.to contain_class("python::install") }
     it { is_expected.to contain_package("pip").with_name('python2-pip') }
+
+    describe "with python::pip_package" do
+      context "dummy-package" do
+        let (:params) {{ :pip_package => 'dummy-package' }}
+        it { is_expected.to contain_package("pip").with_name('dummy-package') }
+      end
+    end
   end
 
   context "on a SLES 11 SP3" do
@@ -345,6 +380,13 @@ describe 'python', :type => :class do
         it { should_not contain_class('epel') }
       end
     end
+
+    describe "with python::pip_package" do
+      context "dummy-package" do
+        let (:params) {{ :pip_package => 'dummy-package' }}
+        it { is_expected.to contain_package("pip").with_name('dummy-package') }
+      end
+    end
   end
 
   context "on a Gentoo OS" do
@@ -414,6 +456,13 @@ describe 'python', :type => :class do
             it { is_expected.to contain_package("virtualenv").with_ensure('absent') }
           end
         end
+      end
+    end
+
+    describe "with python::pip_package" do
+      context "dummy-package" do
+        let (:params) {{ :pip_package => 'dummy-package' }}
+        it { is_expected.to contain_package("pip").with_name('dummy-package') }
       end
     end
   end


### PR DESCRIPTION
This allows you to override the name of the package to install pip
with.

Signed-off-by: David Caro <david@dcaro.es>