### PR TITLE
Fix Python version regex in install.pp

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -215,7 +215,7 @@ class python::install {
         }
       }
 
-      if "${::python::version}" =~ /^3/ { #lint:ignore:only_variable_string
+      if "${::python::version}" =~ /^python3/ { #lint:ignore:only_variable_string
         $pip_category = undef
         $pip_package = 'python3-pip'
       } elsif ($::osfamily == 'RedHat') and (versioncmp($::operatingsystemmajrelease, '7') >= 0) {


### PR DESCRIPTION
According to the rest of the code `version` (if custom) is expected
to contain package name with version.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Fix regex to install correct version of pip
-->

#### This Pull Request (PR) fixes the following issues
<!--
    n/a
-->
