### PR TITLE
support for providing pip3 provider w/ tests. Modified readme 4 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Installs and manages python, python-pip, python-dev, python-virtualenv and Gunic
 
 **use_epel** - Boolean to determine if the epel class is used. Default: true on RHEL like systems, false otherwise
 
+*Install Python from system python*
 ```puppet
   class { 'python' :
     version    => 'system',
@@ -64,6 +65,15 @@ Installs and manages python, python-pip, python-dev, python-virtualenv and Gunic
     dev        => 'absent',
     virtualenv => 'absent',
     gunicorn   => 'absent',
+  }
+```
+*Install Python 3 from the scl repo*
+```puppet
+  class { 'python' :
+    ensure      => 'present',
+    version     => 'rh-python36-python',
+    dev         => 'present',
+    virtualenv  => 'present',
   }
 ```
 
@@ -76,6 +86,8 @@ Installs and manages packages from pip.
 **ensure** - present/latest/absent. You can also specify the version. Default: present
 
 **virtualenv** - virtualenv to run pip in. Default: system (no virtualenv)
+
+**pip_provider** - pip provider to execute pip with. Default: pip.
 
 **url** - URL to install from. Default: none
 
@@ -94,6 +106,8 @@ Installs and manages packages from pip.
 **uninstall_args** - String of additional flags to pass to pip during uninstall. Default: none
 
 **timeout** - Timeout for the pip install command. Defaults to 1800.
+
+*Install cx_Oracle with pip*
 ```puppet
   python::pip { 'cx_Oracle' :
     pkgname       => 'cx_Oracle',
@@ -105,6 +119,17 @@ Installs and manages packages from pip.
     install_args  => '-e',
     timeout       => 1800,
    }
+```
+*Install Requests with pip3*
+```puppet
+  python::pip { 'requests' :
+    ensure        => 'present',
+    pkgname       => 'requests',
+    pip_provider  => 'pip3',
+    virtualenv    => '/var/www/project1',
+    owner         => 'root',
+    timeout       => 1800
+  }
 ```
 
 ### python::requirements

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -16,6 +16,9 @@
 # [*virtualenv*]
 #  virtualenv to run pip in.
 #
+# [*pip_provider*]
+#  version of pip you wish to use. Default: pip
+#
 # [*url*]
 #  URL to install from. Default: none
 #
@@ -66,26 +69,28 @@
 #
 # Sergey Stankevich
 # Fotis Gimian
+# Daniel Quackenbush
 #
 define python::pip (
-  $pkgname         = $name,
-  $ensure          = present,
-  $virtualenv      = 'system',
-  $url             = false,
-  $owner           = 'root',
-  $group           = 'root',
-  $umask           = undef,
-  $index           = false,
-  $proxy           = false,
-  $egg             = false,
-  $editable        = false,
-  $environment     = [],
-  $extras          = [],
-  $install_args    = '',
-  $uninstall_args  = '',
-  $timeout         = 1800,
-  $log_dir         = '/tmp',
-  $path            = ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
+  $pkgname                             = $name,
+  $ensure                              = present,
+  $virtualenv                          = 'system',
+  Enum['pip', 'pip3'] $pip_provider    = 'pip',
+  $url                                 = false,
+  $owner                               = 'root',
+  $group                               = 'root',
+  $umask                               = undef,
+  $index                               = false,
+  $proxy                               = false,
+  $egg                                 = false,
+  $editable                            = false,
+  $environment                         = [],
+  $extras                              = [],
+  $install_args                        = '',
+  $uninstall_args                      = '',
+  $timeout                             = 1800,
+  $log_dir                             = '/tmp',
+  $path                                = ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
 ) {
   $python_provider = getparam(Class['python'], 'provider')
   $python_version  = getparam(Class['python'], 'version')
@@ -125,8 +130,8 @@ define python::pip (
   }
 
   $pip_env = $virtualenv ? {
-    'system' => "${exec_prefix}pip",
-    default  => "${exec_prefix}${virtualenv}/bin/pip",
+    'system' => "${exec_prefix}${pip_provider}",
+    default  => "${exec_prefix}${virtualenv}/bin/${pip_provider}",
   }
 
   $pypi_index = $index ? {

--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -10,6 +10,9 @@
 # [*virtualenv*]
 #  virtualenv to run pip in. Default: system-wide
 #
+# [*pip_provider*]
+#  version of pip you wish to use. Default: pip
+#
 # [*owner*]
 #  The owner of the virtualenv being manipulated. Default: root
 #
@@ -62,22 +65,24 @@
 # Sergey Stankevich
 # Ashley Penney
 # Fotis Gimian
+# Daniel Quackenbush
 #
 define python::requirements (
-  $requirements           = $name,
-  $virtualenv             = 'system',
-  $owner                  = 'root',
-  $group                  = 'root',
-  $proxy                  = false,
-  $src                    = false,
-  $environment            = [],
-  $forceupdate            = false,
-  $cwd                    = undef,
-  $extra_pip_args         = '',
-  $manage_requirements    = true,
-  $fix_requirements_owner = true,
-  $log_dir                = '/tmp',
-  $timeout                = 1800,
+  $requirements                       = $name,
+  $virtualenv                         = 'system',
+  Enum['pip', 'pip3'] $pip_provider   = 'pip',
+  $owner                              = 'root',
+  $group                              = 'root',
+  $proxy                              = false,
+  $src                                = false,
+  $environment                        = [],
+  $forceupdate                        = false,
+  $cwd                                = undef,
+  $extra_pip_args                     = '',
+  $manage_requirements                = true,
+  $fix_requirements_owner             = true,
+  $log_dir                            = '/tmp',
+  $timeout                            = 1800,
 ) {
 
   include ::python
@@ -100,8 +105,8 @@ define python::requirements (
   }
 
   $pip_env = $virtualenv ? {
-    'system' => "${::python::exec_prefix} pip",
-    default  => "${::python::exec_prefix} ${virtualenv}/bin/pip",
+    'system' => "${::python::exec_prefix} ${pip_provider}",
+    default  => "${::python::exec_prefix} ${virtualenv}/bin/${pip_provider}",
   }
 
   $proxy_flag = $proxy ? {

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -38,6 +38,26 @@ describe 'python::pip', type: :define do # rubocop:disable RSpec/MultipleDescrib
       end
     end
 
+    describe 'pip_provide as' do
+      context 'defaults to pip' do
+        let(:params) { {} }
+
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command(%r{pip}) }
+        it { is_expected.not_to contain_exec('pip_install_rpyc').with_command(%r{pip3}) }
+      end
+      context 'use pip instead of pip3 when specified' do
+        let(:params) { { pip_provider: 'pip' } }
+
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command(%r{pip}) }
+        it { is_expected.not_to contain_exec('pip_install_rpyc').with_command(%r{pip3}) }
+      end
+      context 'use pip3 instead of pip when specified' do
+        let(:params) { { pip_provider: 'pip3' } }
+
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command(%r{pip3}) }
+      end
+    end
+
     describe 'proxy as' do
       context 'defaults to empty' do
         let(:params) { {} }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
-->
#### Pull Request (PR) description

- Provide the ability to specify which pip provider to utilize. This will allow support for the use of pip3. Currently the syntax only specifies "pip" this will allow the execution to use "pip3"
- Updated readme to add documentation of how to install anything outside of system python
- Added rspec tests per @bastelfreak recommendations.

#### This Pull Request (PR) fixes the following issues
Fixes #303
Fixes #377 