### PR TITLE
Pip: freeze all to be able to control setuptools, distribute, wheel, pip

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -215,7 +215,7 @@ define python::pip (
     if $ensure != present and $ensure != latest {
       exec { "pip_install_${name}":
         command     => "${wheel_check} ; { ${pip_install} ${install_args} \$wheel_support_flag ${pip_common_args}@${ensure}#egg=${egg_name} || ${pip_install} ${install_args} ${pip_common_args}@${ensure}#egg=${egg_name} ;}",
-        unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+        unless      => "${pip_env} freeze --all | grep -i -e ${grep_regex}",
         user        => $owner,
         group       => $group,
         umask       => $umask,
@@ -227,7 +227,7 @@ define python::pip (
     } else {
       exec { "pip_install_${name}":
         command     => "${wheel_check} ; { ${pip_install} ${install_args} \$wheel_support_flag ${pip_common_args} || ${pip_install} ${install_args} ${pip_common_args} ;}",
-        unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+        unless      => "${pip_env} freeze --all | grep -i -e ${grep_regex}",
         user        => $owner,
         group       => $group,
         umask       => $umask,
@@ -244,7 +244,7 @@ define python::pip (
         # Explicit version.
         exec { "pip_install_${name}":
           command     => "${wheel_check} ; { ${pip_install} ${install_args} \$wheel_support_flag ${pip_common_args}==${ensure} || ${pip_install} ${install_args} ${pip_common_args}==${ensure} ;}",
-          unless      => "${pip_env} freeze | grep -i -e ${grep_regex} || ${pip_env} list | sed -e 's/[ ]\\+/==/' -e 's/[()]//g' | grep -i -e ${grep_regex}",
+          unless      => "${pip_env} freeze --all | grep -i -e ${grep_regex} || ${pip_env} list | sed -e 's/[ ]\\+/==/' -e 's/[()]//g' | grep -i -e ${grep_regex}",
           user        => $owner,
           group       => $group,
           umask       => $umask,
@@ -259,7 +259,7 @@ define python::pip (
         # Whatever version is available.
         exec { "pip_install_${name}":
           command     => "${wheel_check} ; { ${pip_install} \$wheel_support_flag ${pip_common_args} || ${pip_install} ${pip_common_args} ;}",
-          unless      => "${pip_env} freeze | grep -i -e ${grep_regex} || ${pip_env} list | sed -e 's/[ ]\\+/==/' -e 's/[()]//g' | grep -i -e ${grep_regex}",
+          unless      => "${pip_env} freeze --all | grep -i -e ${grep_regex} || ${pip_env} list | sed -e 's/[ ]\\+/==/' -e 's/[()]//g' | grep -i -e ${grep_regex}",
           user        => $owner,
           group       => $group,
           umask       => $umask,
@@ -289,7 +289,7 @@ define python::pip (
         # Anti-action, uninstall.
         exec { "pip_uninstall_${name}":
           command     => "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag} ${name}",
-          onlyif      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+          onlyif      => "${pip_env} freeze --all | grep -i -e ${grep_regex}",
           user        => $owner,
           group       => $group,
           umask       => $umask,

--- a/spec/acceptance/virtualenv_spec.rb
+++ b/spec/acceptance/virtualenv_spec.rb
@@ -53,6 +53,7 @@ describe 'python class' do
 
       # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
   end
 end

--- a/spec/acceptance/virtualenv_spec.rb
+++ b/spec/acceptance/virtualenv_spec.rb
@@ -29,5 +29,30 @@ describe 'python class' do
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
+    it 'maintains pip version' do
+      pp = <<-EOS
+      class { 'python' :
+        version    => 'system',
+        pip        => 'present',
+        virtualenv => 'present',
+      }
+      ->
+      python::virtualenv { 'venv' :
+        ensure     => 'present',
+        systempkgs => false,
+        venv_dir   => '/opt/venv2',
+        owner      => 'root',
+        group      => 'root',
+      }
+      ->
+      python::pip { 'pip' :
+        ensure     => '18.0',
+        virtualenv => '/opt/venv2',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+    end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

By default `pip freeze` skip the mentioned packages and only displays their version if `--all` is used.
As a result, the following code would result in puppet trying to update the pip package every time:
```
    python::pip { 'update-pip' :
      ensure     => '10.0.1',
      pkgname    => 'pip',
      virtualenv => $virtualenv,
    }
```
```
Notice: /Stage[main]/.../Python::Pip[update-pip]/Exec[pip_install_update-pip]/returns: executed successfully
```
With this patch, this recurrent change disappears.

I've added `--all` to all cases, but only tested my own use case...