### PR TITLE
Allow arbitrary pip providers

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -75,7 +75,7 @@ define python::pip (
   $pkgname                             = $name,
   $ensure                              = present,
   $virtualenv                          = 'system',
-  Enum['pip', 'pip3'] $pip_provider    = 'pip',
+  $pip_provider                        = 'pip',
   $url                                 = false,
   $owner                               = 'root',
   $group                               = 'root',


### PR DESCRIPTION


#### Pull Request (PR) description
 This allows expressions such as `python3.6 -m pip` as a provider

#### This Pull Request (PR) fixes the following issues
n/a