### PR TITLE
Install virtualenv instead of python-virtualenv in bionic

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -235,6 +235,8 @@ class python::install {
           $virtualenv_package = 'virtualenv'
         } elsif fact('lsbdistcodename') == 'xenial' {
           $virtualenv_package = 'virtualenv'
+        } elsif fact('lsbdistcodename') == 'bionic' {
+          $virtualenv_package = 'virtualenv'
         } elsif $facts['os']['family'] == 'Gentoo' {
           $virtualenv_package = 'virtualenv'
         } else {


### PR DESCRIPTION
#### Pull Request (PR) description

Support virtualenv in Ubuntu 18.04, installing the `virtualenv` package instead of `
python-virtualenv`
