### PR TITLE
Change default indent to 2 Spaces in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,9 +5,9 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-tab_width = 4
-indent_style = tab
+indent_size = 2
+tab_width = 2
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
#### Pull Request (PR) description
  Many Editors or IDEs support the .editorconfig file and **enforce** it. 
  The "de facto" coding style in this project seems to be 2 spaces indent in *.pp and other files.
  Make this the default for supported editors


