### PR TITLE
Fix Ubuntu bionic package installation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -204,31 +204,34 @@ class python::install {
         }
       }
 
-      if $::osfamily == 'RedHat' {
-        if $pip_ensure != 'absent' {
-          if $python::use_epel == true {
-            include 'epel'
-            Class['epel'] -> Package['pip']
+      case $facts['os']['family'] {
+        'RedHat': {
+          if $pip_ensure != 'absent' {
+            if $python::use_epel == true {
+              include 'epel'
+              Class['epel'] -> Package['pip']
+            }
           }
-        }
-        if ($venv_ensure != 'absent') and ($::operatingsystemrelease =~ /^6/) {
-          if $python::use_epel == true {
-            include 'epel'
-            Class['epel'] -> Package['virtualenv']
+          if ($venv_ensure != 'absent') and ($::operatingsystemrelease =~ /^6/) {
+            if $python::use_epel == true {
+              include 'epel'
+              Class['epel'] -> Package['virtualenv']
+            }
           }
-        }
 
-        $virtualenv_package = "${python}-virtualenv"
-      } else {
-        if fact('lsbdistcodename') == 'jessie' {
+          $virtualenv_package = "${python}-virtualenv"
+        }
+        'Debian': {
+          if fact('lsbdistcodename') == 'trusty' {
+            $virtualenv_package = 'python-virtualenv'
+          } else {
+            $virtualenv_package = 'virtualenv'
+          }
+        }
+        'Gentoo': {
           $virtualenv_package = 'virtualenv'
-        } elsif fact('lsbdistcodename') == 'stretch' {
-          $virtualenv_package = 'virtualenv'
-        } elsif fact('lsbdistcodename') == 'xenial' {
-          $virtualenv_package = 'virtualenv'
-        } elsif $facts['os']['family'] == 'Gentoo' {
-          $virtualenv_package = 'virtualenv'
-        } else {
+        }
+        default: {
           $virtualenv_package = 'python-virtualenv'
         }
       }


### PR DESCRIPTION
This rewrites the OS-specific installation to a more generic case statement. It now only lists the trusty exception for the old naming which makes it future proof.

Replaces https://github.com/voxpupuli/puppet-python/pull/431