### PR TITLE
Allow custom python versions and environments

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,9 +61,9 @@ class python (
     default => '',
   }
 
-  $allowed_versions = concat(['system', 'pypy'], $valid_versions)
-  unless $version =~ Enum[$allowed_versions] {
-    fail("version needs to be within${allowed_versions}")
+  unless $version =~ Pattern[/\A(python)?[0-9](\.[0-9])+/,
+        /\Apypy\Z/, /\Asystem\Z/] {
+    fail("version needs to be pypy, system or a version string like '3.5' or 'python3.5)")
   }
 
   # Module compatibility check

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,7 +10,8 @@ class python::install {
   $python = $python_version ? {
     'system' => 'python',
     'pypy'   => 'pypy',
-    default  => "${python_version}", # lint:ignore:only_variable_string
+    /\A(python)?([0-9](\.?[0-9])+)/ => "python${1}",
+    default  => "python${python::version}",
   }
 
   $pythondev = $facts['os']['family'] ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,13 +12,7 @@ class python::params {
   $gunicorn               = 'absent'
   $manage_gunicorn        = true
   $provider               = undef
-  $valid_versions = $::osfamily ? {
-    'RedHat' => ['3','27','33'],
-    'Debian' => ['3', '3.3', '2.7'],
-    'Suse'   => [],
-    'AIX'   => ['python3'],
-    'Gentoo' => ['2.7', '3.3', '3.4', '3.5']
-  }
+  $valid_versions         = undef
 
   if $::osfamily == 'RedHat' {
     if $::operatingsystem != 'Fedora' {

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -71,6 +71,11 @@ define python::pip (
   $python_provider = getparam(Class['python'], 'provider')
   $python_version  = getparam(Class['python'], 'version')
 
+  if $virtualenv != 'system' {
+    Python::Pyvenv <| |> -> Python::Pip[$name]
+    Python::Virtualenv <| |> -> Python::Pip[$name]
+  }
+
   # Get SCL exec prefix
   # NB: this will not work if you are running puppet from scl enabled shell
   $exec_prefix = $python_provider ? {

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -47,8 +47,6 @@ define python::pyvenv (
       case $facts['os']['distro']['codename'] {
          'xenial','bionic','cosmic','disco',
         'jessie','stretch','buster': {
-          notify {"python3_venv_package: $python3_venv_package":
-          }
           package {$python3_venv_package:
             before => File[$venv_dir],
           }

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -37,15 +37,15 @@ define python::pyvenv (
 
   if $ensure == 'present' {
     $python_version = $version ? {
-        'system' => "$::python3_version",
-        default  => "${version}",
+        'system' => $facts['python3_version'],
+        default  => $version,
     }
 
     # Debian splits the venv module into a seperate package
     if ( $facts['os']['family'] == 'Debian'){
       $python3_venv_package="python${python_version}-venv"
-      case $facts['os']['distro']['codename'] {
-         'xenial','bionic','cosmic','disco',
+      case $facts['lsbdistcodename'] {
+        'xenial','bionic','cosmic','disco',
         'jessie','stretch','buster': {
           package {$python3_venv_package:
             before => File[$venv_dir],
@@ -56,7 +56,7 @@ define python::pyvenv (
     }
 
     # pyvenv is deprecated since 3.6 and will be removed in 3.8
-    if (versioncmp($::python3_version, '3.6') >=0) {
+    if (versioncmp($facts['python3_version'], '3.6') >=0) {
       $virtualenv_cmd = "${python::exec_prefix}python${python_version}  -m venv"
     } else {
       $virtualenv_cmd = "${python::exec_prefix}pyvenv-${python_version}"

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -47,9 +47,9 @@ define python::pyvenv (
       case $facts['lsbdistcodename'] {
         'xenial','bionic','cosmic','disco',
         'jessie','stretch','buster': {
-          package {$python3_venv_package:
+          ensure_packages ($python3_venv_package, {
             before => File[$venv_dir],
-          }
+          })
         }
           default: {}
       }

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -36,13 +36,19 @@ define python::pyvenv (
   include ::python
 
   if $ensure == 'present' {
+    $python_version = $version ? {
+        'system' => "$::python3_version",
+        default  => "${version}",
+    }
 
     # Debian splits the venv module into a seperate package
     if ( $facts['os']['family'] == 'Debian'){
-      $python3_venv_package="python${version}-venv"
+      $python3_venv_package="python${python_version}-venv"
       case $facts['os']['distro']['codename'] {
          'xenial','bionic','cosmic','disco',
         'jessie','stretch','buster': {
+          notify {"python3_venv_package: $python3_venv_package":
+          }
           package {$python3_venv_package:
             before => File[$venv_dir],
           }
@@ -53,15 +59,9 @@ define python::pyvenv (
 
     # pyvenv is deprecated since 3.6 and will be removed in 3.8
     if (versioncmp($::python3_version, '3.6') >=0) {
-      $virtualenv_cmd = $version ? {
-        'system' => "${python::exec_prefix}python3 -m venv",
-        default  => "${python::exec_prefix}python${version} -m venv",
-      }
+      $virtualenv_cmd = "${python::exec_prefix}python${python_version}  -m venv"
     } else {
-      $virtualenv_cmd = $version ? {
-        'system' => "${python::exec_prefix}pyvenv",
-        default  => "${python::exec_prefix}pyvenv-${version}",
-      }
+      $virtualenv_cmd = "${python::exec_prefix}pyvenv-${python_version}"
     }
 
     $_path = $::python::provider ? {

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,0 +1,3 @@
+---
+python_version: "2.7"
+python3_version: ~

--- a/spec/defines/pyvenv_spec.rb
+++ b/spec/defines/pyvenv_spec.rb
@@ -4,7 +4,10 @@ describe 'python::pyvenv', type: :define do
   on_supported_os.each do |os, facts|
     context("on #{os} ") do
       let :facts do
-        facts
+        # python3 is required to use pyvenv
+        facts.merge(
+          python3_version: '3.4'
+        )
       end
       let :title do
         '/opt/env'
@@ -12,7 +15,7 @@ describe 'python::pyvenv', type: :define do
 
       it {
         is_expected.to contain_file('/opt/env')
-        is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv --clear  /opt/env')
+        is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.4 --clear  /opt/env')
       }
 
       describe 'when ensure' do
@@ -28,6 +31,6 @@ describe 'python::pyvenv', type: :define do
           }
         end
       end
-    end
+    end # context
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request allows to install all python versions and create **pyenv** or **virtualenv** environments
with those versions. 
This also adds the missing _venv_ module in newer Debian based distributions and addresses the deprecation of _pyenv_ in 3.6 with an expected removal of it in Python 3.8.


#### This Pull Request (PR) fixes the following issues
 Fixes #448
 Fixes the first part of #430 "pip3 missing in the virtualenv ?"