### PR TITLE
Allow pip to work in AIX systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,7 @@ class python (
   }
 
   # Module compatibility check
-  $compatible = [ 'Debian', 'RedHat', 'Suse', 'Gentoo' ]
+  $compatible = [ 'Debian', 'RedHat', 'Suse', 'Gentoo', 'AIX' ]
   if ! ($facts['os']['family'] in $compatible) {
     fail("Module is not compatible with ${::operatingsystem}")
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,7 +13,7 @@ class python::install {
   }
 
   $pythondev = $facts['os']['family'] ? {
-    'AIX' => "${python}-devel",
+    'AIX'    => "${python}-devel",
     'RedHat' => "${python}-devel",
     'Debian' => "${python}-dev",
     'Suse'   => "${python}-devel",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -84,7 +84,7 @@ class python::install {
       Package <| title == 'virtualenv' |> {
         name     => 'virtualenv',
         provider => 'pip',
-        require  => Package['python-dev'],
+        require  => Package[$pythondev],
       }
     }
     'scl': {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,10 +6,11 @@
 #
 class python::install {
 
-  $python = $::python::version ? {
+  $python_version = getparam(Class['python'], 'version')
+  $python = $python_version ? {
     'system' => 'python',
     'pypy'   => 'pypy',
-    default  => "${python::version}", # lint:ignore:only_variable_string
+    default  => "${python_version}", # lint:ignore:only_variable_string
   }
 
   $pythondev = $facts['os']['family'] ? {
@@ -180,7 +181,7 @@ class python::install {
     default: {
       case $facts['os']['family'] {
         'AIX': {
-          if "${python::version}" =~ /^python3/ { #lint:ignore:only_variable_string
+          if "${python_version}" =~ /^python3/ { #lint:ignore:only_variable_string
             class { 'python::pip::bootstap':
                     version => 'pip3',
             }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -180,7 +180,7 @@ class python::install {
     default: {
       case $facts['os']['family'] {
         'AIX': {
-          if "${::python::version}" =~ /^python3/ { #lint:ignore:only_variable_string
+          if "${python::version}" =~ /^python3/ { #lint:ignore:only_variable_string
             class { 'python::pip::bootstap':
                     version => 'pip3',
             }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,6 @@
-# @api private
-# @summary The python Module default configuration settings.
+# == Class: python::params
+#
+# The python Module default configuration settings.
 #
 class python::params {
   $ensure                 = 'present'
@@ -14,6 +15,7 @@ class python::params {
     'RedHat' => ['3','27','33'],
     'Debian' => ['3', '3.3', '2.7'],
     'Suse'   => [],
+    'AIX'   => ['python3'],
     'Gentoo' => ['2.7', '3.3', '3.4', '3.5']
   }
 
@@ -27,12 +29,17 @@ class python::params {
     $use_epel             = false
   }
 
+  $group = $facts['os']['family'] ? {
+    'AIX' => 'system',
+    default => 'root'
+  }
+
   $pip_lookup_path = $facts['os']['family'] ? {
     'AIX' => [ '/bin', '/usr/bin', '/usr/local/bin', '/opt/freeware/bin/' ],
     default => [ '/bin', '/usr/bin', '/usr/local/bin' ]
   }
 
-  $gunicorn_package_name = $::osfamily ? {
+  $gunicorn_package_name = $facts['os']['family'] ? {
     'RedHat' => 'python-gunicorn',
     default  => 'gunicorn',
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,5 @@
-# == Class: python::params
+# @api private
+# @summary The python Module default configuration settings.
 #
 # The python Module default configuration settings.
 #

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -55,7 +55,7 @@ define python::pip (
   Enum['pip', 'pip3'] $pip_provider                          = 'pip',
   Variant[Boolean, String] $url                              = false,
   String[1] $owner                                           = 'root',
-  $group                                                     = undef,
+  $group                                                     = getparam(Class['python'], 'group'),
   $umask                                                     = undef,
   $index                                                     = false,
   Variant[Boolean, String] $proxy                            = false,
@@ -71,11 +71,7 @@ define python::pip (
 ){
   $python_provider = getparam(Class['python'], 'provider')
   $python_version  = getparam(Class['python'], 'version')
-  if $group {
-    $_group = $group
-  } else {
-    $_group = getparam(Class['python'], 'group')
-  }
+
   # Get SCL exec prefix
   # NB: this will not work if you are running puppet from scl enabled shell
   $exec_prefix = $python_provider ? {
@@ -187,7 +183,7 @@ define python::pip (
         command     => "${wheel_check} ; { ${pip_install} ${install_args} \$wheel_support_flag ${pip_common_args}@${ensure}#egg=${egg_name} || ${pip_install} ${install_args} ${pip_common_args}@${ensure}#egg=${egg_name} ;}",
         unless      => "${pip_env} freeze --all | grep -i -e ${grep_regex}",
         user        => $owner,
-        group       => $_group,
+        group       => $group,
         umask       => $umask,
         cwd         => $cwd,
         environment => $environment,
@@ -199,7 +195,7 @@ define python::pip (
         command     => "${wheel_check} ; { ${pip_install} ${install_args} \$wheel_support_flag ${pip_common_args} || ${pip_install} ${install_args} ${pip_common_args} ;}",
         unless      => "${pip_env} freeze --all | grep -i -e ${grep_regex}",
         user        => $owner,
-        group       => $_group,
+        group       => $group,
         umask       => $umask,
         cwd         => $cwd,
         environment => $environment,
@@ -216,7 +212,7 @@ define python::pip (
           command     => "${wheel_check} ; { ${pip_install} ${install_args} \$wheel_support_flag ${pip_common_args}==${ensure} || ${pip_install} ${install_args} ${pip_common_args}==${ensure} ;}",
           unless      => "${pip_env} freeze --all | grep -i -e ${grep_regex} || ${pip_env} list | sed -e 's/[ ]\\+/==/' -e 's/[()]//g' | grep -i -e ${grep_regex}",
           user        => $owner,
-          group       => $_group,
+          group       => $group,
           umask       => $umask,
           cwd         => $cwd,
           environment => $environment,
@@ -231,7 +227,7 @@ define python::pip (
           command     => "${wheel_check} ; { ${pip_install} \$wheel_support_flag ${pip_common_args} || ${pip_install} ${pip_common_args} ;}",
           unless      => "${pip_env} freeze --all | grep -i -e ${grep_regex} || ${pip_env} list | sed -e 's/[ ]\\+/==/' -e 's/[()]//g' | grep -i -e ${grep_regex}",
           user        => $owner,
-          group       => $_group,
+          group       => $group,
           umask       => $umask,
           cwd         => $cwd,
           environment => $environment,
@@ -262,7 +258,7 @@ define python::pip (
           command     => "${wheel_check} ; { ${pip_install} --upgrade \$wheel_support_flag ${pip_common_args} || ${pip_install} --upgrade ${pip_common_args} ;}",
           unless      => $unless_command,
           user        => $owner,
-          group       => $_group,
+          group       => $group,
           umask       => $umask,
           cwd         => $cwd,
           environment => $environment,
@@ -277,7 +273,7 @@ define python::pip (
           command     => "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag} ${name}",
           onlyif      => "${pip_env} freeze --all | grep -i -e ${grep_regex}",
           user        => $owner,
-          group       => $_group,
+          group       => $group,
           umask       => $umask,
           cwd         => $cwd,
           environment => $environment,

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -54,7 +54,7 @@ define python::pip (
   Enum['pip', 'pip3'] $pip_provider                          = 'pip',
   Variant[Boolean, String] $url                              = false,
   String[1] $owner                                           = 'root',
-  $group                                                     = getparam(Class['python'], 'group'),
+  $group                                                     = getvar('python::params::group'),
   $umask                                                     = undef,
   $index                                                     = false,
   Variant[Boolean, String] $proxy                            = false,

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -1,4 +1,3 @@
-getparam(Class['python'], 'version')
 # @summary Installs and manages packages from pip.
 #
 # @param name must be unique

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -1,4 +1,4 @@
-
+getparam(Class['python'], 'version')
 # @summary Installs and manages packages from pip.
 #
 # @param name must be unique
@@ -74,8 +74,7 @@ define python::pip (
   if $group {
     $_group = $group
   } else {
-    include ::python::params
-    $_group = $python::params::group
+    $_group = getparam(Class['python'], 'group')
   }
   # Get SCL exec prefix
   # NB: this will not work if you are running puppet from scl enabled shell

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,11 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "AIX"
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "6100-09-11-1810",
+        "7100-05-03-1837"
+      ]
     },
     {
       "operatingsystem": "CentOS",

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,9 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "AIX"
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",


### PR DESCRIPTION
This changes allow installing python and pip modules, assuming that you have yum previously configured as per described at
https://www.ibm.com/developerworks/aix/library/aix-toolbox/date.html
It have been tested on AIX 6 and 7

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
