### PR TITLE
Add manage_scl boolean to control managing SCL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@
 # @param manage_gunicorn Allow Installation / Removal of Gunicorn.
 # @param provider What provider to use for installation of the packages, except gunicorn and Python itself.
 # @param use_epel to determine if the epel class is used.
+# @param manage_scl Whether to manage core SCL packages or not.
 #
 # @example install python from system python
 #   class { 'python':
@@ -25,7 +26,7 @@
 #     virtualenv => 'present',
 #     gunicorn   => 'present',
 #   }
-# @example install python3 from scl report
+# @example install python3 from scl repo
 #   class { 'python' :
 #     ensure      => 'present',
 #     version     => 'rh-python36-python',
@@ -53,6 +54,7 @@ class python (
   $rhscl_use_public_repository                    = $python::params::rhscl_use_public_repository,
   Stdlib::Httpurl $anaconda_installer_url         = $python::params::anaconda_installer_url,
   Stdlib::Absolutepath $anaconda_install_path     = $python::params::anaconda_install_path,
+  Boolean $manage_scl                             = $python::params::manage_scl,
 ) inherits python::params {
 
   $exec_prefix = $provider ? {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -93,18 +93,26 @@ class python::install {
       # SCL is only valid in the RedHat family. If RHEL, package must be
       # enabled using the subscription manager outside of puppet. If CentOS,
       # the centos-release-SCL will install the repository.
-      $install_scl_repo_package = $::operatingsystem ? {
-        'CentOS' => 'present',
-        default  => 'absent',
-      }
+      if $python::manage_scl {
+        $install_scl_repo_package = $facts['os']['name'] ? {
+          'CentOS' => 'present',
+          default  => 'absent',
+        }
 
-      package { 'centos-release-scl':
-        ensure => $install_scl_repo_package,
-        before => Package['scl-utils'],
-      }
-      package { 'scl-utils':
-        ensure => 'latest',
-        before => Package['python'],
+        package { 'centos-release-scl':
+          ensure => $install_scl_repo_package,
+          before => Package['scl-utils'],
+        }
+        package { 'scl-utils':
+          ensure => 'present',
+          before => Package['python'],
+        }
+
+        Package['scl-utils'] -> Package["${python}-scldevel"]
+
+        if $pip_ensure != 'absent' {
+          Package['scl-utils'] -> Exec['python-scl-pip-install']
+        }
       }
 
       # This gets installed as a dependency anyway
@@ -113,15 +121,13 @@ class python::install {
       #   require => Package['scl-utils'],
       # }
       package { "${python}-scldevel":
-        ensure  => $dev_ensure,
-        require => Package['scl-utils'],
+        ensure => $dev_ensure,
       }
       if $pip_ensure != 'absent' {
         exec { 'python-scl-pip-install':
           command => "${python::exec_prefix}easy_install pip",
           path    => ['/usr/bin', '/bin'],
           creates => "/opt/rh/${python::version}/root/usr/bin/pip",
-          require => Package['scl-utils'],
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class python::params {
   $manage_gunicorn        = true
   $provider               = undef
   $valid_versions         = undef
+  $manage_scl             = true
 
   if $::osfamily == 'RedHat' {
     if $::operatingsystem != 'Fedora' {

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -204,6 +204,23 @@ describe 'python', type: :class do
                   }
                 end
 
+                context 'scl' do
+                  describe 'with manage_scl' do
+                    context 'true' do
+                      let(:params) { { provider: 'scl', manage_scl: true } }
+
+                      it { is_expected.to contain_package('centos-release-scl') }
+                      it { is_expected.to contain_package('scl-utils') }
+                    end
+                    context 'false' do
+                      let(:params) { { provider: 'scl', manage_scl: false } }
+
+                      it { is_expected.not_to contain_package('centos-release-scl') }
+                      it { is_expected.not_to contain_package('scl-utils') }
+                    end
+                  end
+                end
+
                 # python::provider
                 context 'default' do
                   let(:params) { { provider: '' } }


### PR DESCRIPTION
#### Pull Request (PR) description
This adds a `manage_scl` boolean which can be set to `false` to stop managing the various SCL packages in the case some other module is doing that already.

#### This Pull Request (PR) fixes the following issues
Fixes #463 
