### PR TITLE
Revert "drop EOL operatingsystems"

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
+        "5",
         "6",
         "7"
       ]
@@ -32,6 +33,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
+        "6",
+        "7",
         "8",
         "9"
       ]
@@ -42,6 +45,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "10.04",
+        "12.04",
         "14.04",
         "16.04",
         "18.04"


### PR DESCRIPTION
This reverts commit c9693a32cb2dbae3ec41c3a70c8035016d549836 as we still need to use the module on some of our servers that run on Precise.

