### PR TITLE
Normalize Python version in `python::pyvenv`

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -244,7 +244,7 @@ define python::pip (
         # Unfortunately this is the smartest way of getting the latest available package version with pip as of now
         # Note: we DO need to repeat ourselves with "from version" in both grep and sed as on some systems pip returns
         # more than one line with paretheses.
-        $latest_version = join(["${pip_env} install ${proxy_flag} ${pkgname}==notreallyaversion 2>&1",
+        $latest_version = join(["${pip_install} ${pypi_index} ${proxy_flag} ${install_args} ${install_editable} ${pkgname}==notreallyaversion 2>&1",
                                 ' | grep -oP "\(from versions: .*\)" | sed -E "s/\(from versions: (.*?, )*(.*)\)/\2/g"',
                                 ' | tr -d "[:space:]"'])
 

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -41,9 +41,12 @@ define python::pyvenv (
         default  => $version,
     }
 
+    $python_version_parts = split($python_version, '[.]')
+    $normalized_python_version = sprintf('%s.%s', $python_version_parts[0], $python_version_parts[1])
+
     # Debian splits the venv module into a seperate package
     if ( $facts['os']['family'] == 'Debian'){
-      $python3_venv_package="python${python_version}-venv"
+      $python3_venv_package="python${normalized_python_version}-venv"
       case $facts['lsbdistcodename'] {
         'xenial','bionic','cosmic','disco',
         'jessie','stretch','buster': {
@@ -57,9 +60,9 @@ define python::pyvenv (
 
     # pyvenv is deprecated since 3.6 and will be removed in 3.8
     if (versioncmp($facts['python3_version'], '3.6') >=0) {
-      $virtualenv_cmd = "${python::exec_prefix}python${python_version}  -m venv"
+      $virtualenv_cmd = "${python::exec_prefix}python${normalized_python_version} -m venv"
     } else {
-      $virtualenv_cmd = "${python::exec_prefix}pyvenv-${python_version}"
+      $virtualenv_cmd = "${python::exec_prefix}pyvenv-${normalized_python_version}"
     }
 
     $_path = $::python::provider ? {

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -61,7 +61,7 @@ describe 'python', type: :class do
 
           describe 'with python::provider' do
             context 'pip' do
-              let(:params) { { provider: 'pip' } }
+              let(:params) { { pip: 'present', provider: 'pip' } }
 
               it {
                 is_expected.to contain_package('virtualenv').with(
@@ -384,7 +384,7 @@ describe 'python', type: :class do
 
           describe 'with python::provider' do
             context 'pip' do
-              let(:params) { { provider: 'pip' } }
+              let(:params) { { pip: 'present', provider: 'pip' } }
 
               it {
                 is_expected.to contain_package('virtualenv').with(

--- a/spec/defines/pyvenv_spec.rb
+++ b/spec/defines/pyvenv_spec.rb
@@ -6,7 +6,7 @@ describe 'python::pyvenv', type: :define do
       let :facts do
         # python3 is required to use pyvenv
         facts.merge(
-          python3_version: '3.4'
+          python3_version: '3.5.1'
         )
       end
       let :title do
@@ -15,7 +15,7 @@ describe 'python::pyvenv', type: :define do
 
       it {
         is_expected.to contain_file('/opt/env')
-        is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.4 --clear  /opt/env')
+        is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear  /opt/env')
       }
 
       describe 'when ensure' do


### PR DESCRIPTION
This fixes the issue where a Python version value is composed of 3 or more numbers.