### PR TITLE
Update `puppetlabs/stdlib` dependency to allow 6.x and require at least 4.19.0 (where the `fact()` function was introduced)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -63,7 +63,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.19.0 < 7.0.0"
     },
     {
       "name": "stahnma/epel",


### PR DESCRIPTION
Fixes: #458 