### PR TITLE
Fix version-check.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,9 +65,9 @@ class python (
     default => '',
   }
 
-  unless $version =~ Pattern[/\A(python)?[0-9](\.[0-9])+/,
+  unless $version =~ Pattern[/\A(python)?[0-9](\.?[0-9])+/,
         /\Apypy\Z/, /\Asystem\Z/, /\Arh-python[0-9]{2}(?:-python)?\Z/] {
-    fail("version needs to be pypy, system or a version string like '3.5' or 'python3.5)")
+    fail("version needs to be pypy, system or a version string like '36', '3.6' or 'python3.6' )")
   }
 
   # Module compatibility check

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -157,16 +157,16 @@ define python::pip (
 
   $source = $url ? {
     false               => "${pkgname}${extras_string}",
-    /^(\/|[a-zA-Z]\:)/  => $url,
-    /^(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp|git)(:\/\/).+$/ => $url,
-    default             => "${url}#egg=${egg_name}",
+    /^(\/|[a-zA-Z]\:)/  => "'${url}'",
+    /^(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp|git)(:\/\/).+$/ => "'${url}'",
+    default             => "'${url}#egg=${egg_name}'",
   }
 
   $pip_install = "${pip_env} --log ${log}/pip.log install"
   $pip_common_args = "${pypi_index} ${proxy_flag} ${install_args} ${install_editable} ${source}"
 
   # Explicit version out of VCS when PIP supported URL is provided
-  if $source =~ /^(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp|git)(:\/\/).+$/ {
+  if $source =~ /^'(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp|git)(:\/\/).+'$/ {
     if $ensure != present and $ensure != latest {
       exec { "pip_install_${name}":
         command     => "${pip_install} ${install_args} ${pip_common_args}@${ensure}#egg=${egg_name}",

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -85,7 +85,7 @@ define python::pip (
   }
 
   $_path = $python_provider ? {
-    'anaconda' => concat(["${::python::anaconda_install_path}/bin"], $path),
+    'anaconda' => concat(["${python::anaconda_install_path}/bin"], $path),
     default    => $path,
   }
 

--- a/manifests/pip/bootstrap.pp
+++ b/manifests/pip/bootstrap.pp
@@ -13,7 +13,7 @@ class python::pip::bootstrap (
   Enum['pip', 'pip3'] $version            = 'pip',
   Variant[Boolean, String] $manage_python = false,
   Optional[Stdlib::HTTPUrl] $http_proxy   = undef,
-) inherits ::python::params {
+) inherits python::params {
   if $manage_python {
     include python
   } else {

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -65,8 +65,8 @@ define python::pyvenv (
       $virtualenv_cmd = "${python::exec_prefix}pyvenv-${normalized_python_version}"
     }
 
-    $_path = $::python::provider ? {
-      'anaconda' => concat(["${::python::anaconda_install_path}/bin"], $path),
+    $_path = $python::provider ? {
+      'anaconda' => concat(["${python::anaconda_install_path}/bin"], $path),
       default    => $path,
     }
 

--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -63,8 +63,8 @@ define python::requirements (
   }
 
   $pip_env = $virtualenv ? {
-    'system' => "${::python::exec_prefix} ${pip_provider}",
-    default  => "${::python::exec_prefix} ${virtualenv}/bin/${pip_provider}",
+    'system' => "${python::exec_prefix} ${pip_provider}",
+    default  => "${python::exec_prefix} ${virtualenv}/bin/${pip_provider}",
   }
 
   $proxy_flag = $proxy ? {

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -314,6 +314,17 @@ describe 'python', type: :class do
               it { is_expected.to contain_class('python::install') }
               it { is_expected.to contain_package('pip').with_name('python2-pip') }
 
+              describe 'with python::version' do
+                context 'python36' do
+                  let(:params) { { version: 'python36' } }
+
+                  it { is_expected.to compile.with_all_deps }
+                  it { is_expected.to contain_package('pip').with_name('python36-pip') }
+                  it { is_expected.to contain_package('python').with_name('python36') }
+                  it { is_expected.to contain_package('python-dev').with_name('python36-devel') }
+                  it { is_expected.to contain_package('virtualenv').with_name('python36-virtualenv') }
+                end
+              end
               describe 'with python::provider' do
                 context 'scl' do
                   describe 'with version' do

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -87,7 +87,7 @@ describe 'python::pip', type: :define do # rubocop:disable RSpec/MultipleDescrib
     describe 'path as' do
       context 'adds anaconda path to pip invocation if provider is anaconda' do
         let(:params) { {} }
-        let(:pre_condition) { 'class {"::python": provider => "anaconda", anaconda_install_path => "/opt/python3"}' }
+        let(:pre_condition) { 'class {"python": provider => "anaconda", anaconda_install_path => "/opt/python3"}' }
 
         it { is_expected.to contain_exec('pip_install_rpyc').with_path(['/opt/python3/bin', '/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin']) }
       end


### PR DESCRIPTION
Fixes #303
Fixes #354
Fixes #420
Fixes #429 
Fixes #444
Fixes #476

Allows Python3 installation on Centos-7 thusly:

```
class { 'python':
  version: 'python36'
}
```