### PR TITLE
Fix $subscribe overloading

### DIFF
--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -89,9 +89,9 @@ define python::requirements (
       replace => false,
       content => '# Puppet will install and/or update pip packages listed here',
     }
-    $subscribe = File[$requirements]
+    $local_subscribe = File[$requirements]
   } else {
-    $subscribe = undef
+    $local_subscribe = undef
   }
 
   exec { "python_requirements${name}":
@@ -101,7 +101,7 @@ define python::requirements (
     timeout     => $timeout,
     cwd         => $cwd,
     user        => $owner,
-    subscribe   => $subscribe,
+    subscribe   => $local_subscribe,
     environment => $environment,
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

In python::requirements, we simply rename $subscribe to $local_subscribe, to prevent it being redefined. This is a puppet metaparameter so should not be used as a variable within in a define.

#### This Pull Request (PR) fixes the following issues

Fixes #470 
