### PR TITLE
Fix python::pip installing $editable VCS packages every Puppet run

### DIFF
--- a/spec/acceptance/virtualenv_spec.rb
+++ b/spec/acceptance/virtualenv_spec.rb
@@ -27,6 +27,7 @@ describe 'python class' do
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
+
     it 'maintains pip version' do
       pp = <<-EOS
       class { 'python' :
@@ -51,6 +52,7 @@ describe 'python class' do
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
+
     it 'works with ensure=>latest' do
       pp = <<-EOS
       class { 'python' :
@@ -77,6 +79,7 @@ describe 'python class' do
       # but probability of this happening is minimal, so it should be acceptable.
       apply_manifest(pp, catch_changes: true)
     end
+
     it 'works with ensure=>latest for package with underscore in its name' do
       pp = <<-EOS
       class { 'python' :
@@ -103,6 +106,7 @@ describe 'python class' do
       # but probability of this happening is minimal, so it should be acceptable.
       apply_manifest(pp, catch_changes: true)
     end
+
     it 'works with editable=>true' do
       pp = <<-EOS
       package{ 'git' :
@@ -125,6 +129,30 @@ describe 'python class' do
         url        => 'git+https://github.com/tomerfiliba/rpyc.git',
         editable   => true,
         virtualenv => '/opt/venv5',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'works with == in pkgname' do
+      pp = <<-EOS
+      class { 'python' :
+        version    => 'system',
+        pip        => 'present',
+        virtualenv => 'present',
+      }
+      -> python::virtualenv { 'venv' :
+        ensure     => 'present',
+        systempkgs => false,
+        venv_dir   => '/opt/venv6',
+        owner      => 'root',
+        group      => 'root',
+      }
+      -> python::pip { 'rpyc==4.1.0' :
+        virtualenv => '/opt/venv6',
       }
       EOS
 

--- a/spec/acceptance/virtualenv_spec.rb
+++ b/spec/acceptance/virtualenv_spec.rb
@@ -10,16 +10,14 @@ describe 'python class' do
         pip        => 'present',
         virtualenv => 'present',
       }
-      ->
-      python::virtualenv { 'venv' :
+      -> python::virtualenv { 'venv' :
         ensure     => 'present',
         systempkgs => false,
         venv_dir   => '/opt/venv',
         owner      => 'root',
         group      => 'root',
       }
-      ->
-      python::pip { 'rpyc' :
+      -> python::pip { 'rpyc' :
         ensure     => '3.2.3',
         virtualenv => '/opt/venv',
       }
@@ -36,16 +34,14 @@ describe 'python class' do
         pip        => 'present',
         virtualenv => 'present',
       }
-      ->
-      python::virtualenv { 'venv' :
+      -> python::virtualenv { 'venv' :
         ensure     => 'present',
         systempkgs => false,
         venv_dir   => '/opt/venv2',
         owner      => 'root',
         group      => 'root',
       }
-      ->
-      python::pip { 'pip' :
+      -> python::pip { 'pip' :
         ensure     => '18.0',
         virtualenv => '/opt/venv2',
       }
@@ -62,16 +58,14 @@ describe 'python class' do
         pip        => 'present',
         virtualenv => 'present',
       }
-      ->
-      python::virtualenv { 'venv' :
+      -> python::virtualenv { 'venv' :
         ensure     => 'present',
         systempkgs => false,
         venv_dir   => '/opt/venv3',
         owner      => 'root',
         group      => 'root',
       }
-      ->
-      python::pip { 'rpyc' :
+      -> python::pip { 'rpyc' :
         ensure     => 'latest',
         virtualenv => '/opt/venv3',
       }
@@ -90,16 +84,14 @@ describe 'python class' do
         pip        => 'present',
         virtualenv => 'present',
       }
-      ->
-      python::virtualenv { 'venv' :
+      -> python::virtualenv { 'venv' :
         ensure     => 'present',
         systempkgs => false,
         venv_dir   => '/opt/venv4',
         owner      => 'root',
         group      => 'root',
       }
-      ->
-      python::pip { 'Randomized_Requests' :
+      -> python::pip { 'Randomized_Requests' :
         ensure     => 'latest',
         virtualenv => '/opt/venv4',
       }
@@ -109,6 +101,35 @@ describe 'python class' do
       apply_manifest(pp, catch_failures: true)
       # Of course this test will fail if between the applies a new version of the package will be released,
       # but probability of this happening is minimal, so it should be acceptable.
+      apply_manifest(pp, catch_changes: true)
+    end
+    it 'works with editable=>true' do
+      pp = <<-EOS
+      package{ 'git' :
+        ensure => 'present',
+      }
+      -> class { 'python' :
+        version    => 'system',
+        pip        => 'present',
+        virtualenv => 'present',
+      }
+      -> python::virtualenv { 'venv' :
+        ensure     => 'present',
+        systempkgs => false,
+        venv_dir   => '/opt/venv5',
+        owner      => 'root',
+        group      => 'root',
+      }
+      -> python::pip { 'rpyc' :
+        ensure     => '4.1.0',
+        url        => 'git+https://github.com/tomerfiliba/rpyc.git',
+        editable   => true,
+        virtualenv => '/opt/venv5',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
This is due to VCS packages appearing in `pip freeze -all` as:
-e git://example.com/package.git@<ref>#egg=<egg>

Updates $grep_regex, which checks whether a given version is installed, to
match against the two different output formats of `pip list`. No longer
relies on pip freeze.

Additionally, this commit:

Removes the multiple exec resources which were mostly the same and replaces
with variables $pip_exec_name, $command, and $unless_command, which get
used in a single exec resource at the end of the manifest.

Checks if $pkgname contains ==, and if so splits based on == and sets
$real_pkgname to the first part, and $ensure variable to the second part.
Uses of $pkgname have been replaced with $real_pkgname.

#### This Pull Request (PR) fixes the following issues
Fixes #193
