### PR TITLE
Fix a reassigned variable

### DIFF
--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -106,6 +106,16 @@ describe 'python::pip', type: :define do # rubocop:disable RSpec/MultipleDescrib
         it { is_expected.to contain_exec('pip_install_rpyc').with_unless(%r{wordpress-json}) }
       end
     end
+
+    describe 'uninstall' do
+      context 'adds correct title' do
+        let(:params) { { ensure: 'absent' } }
+
+        it { is_expected.not_to contain_exec('pip_install_rpyc') }
+
+        it { is_expected.to contain_exec('pip_uninstall_rpyc').with_command(%r{uninstall.*rpyc$}) }
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This occurred when $ensure was set to 'absent'. Then the variable used
for the title of the exec resource was assigned twice, resulting in an
error.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I solved it via a variable to avoid having to set the title in several places.
Of course, I can also put the title of the exec resource into another variable if the syntax there looks too weird. Please let me know if I should do this.

#### This Pull Request (PR) fixes the following issues
Fixes #496
