### PR TITLE
Use shell to exec pip commands by default

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -67,6 +67,7 @@ define python::pip (
   Numeric $timeout                                           = 1800,
   String[1] $log_dir                                         = '/tmp',
   Array[String] $path                                        = ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
+  String[1] $exec_provider                                   = 'shell',
 ){
   $python_provider = getparam(Class['python'], 'provider')
   $python_version  = getparam(Class['python'], 'version')
@@ -238,6 +239,7 @@ define python::pip (
     environment => $environment,
     timeout     => $timeout,
     path        => $_path,
+    provider    => $exec_provider,
   }
 
 }

--- a/manifests/pip/bootstrap.pp
+++ b/manifests/pip/bootstrap.pp
@@ -13,6 +13,7 @@ class python::pip::bootstrap (
   Enum['pip', 'pip3'] $version            = 'pip',
   Variant[Boolean, String] $manage_python = false,
   Optional[Stdlib::HTTPUrl] $http_proxy   = undef,
+  String[1] $exec_provider                = 'shell',
 ) inherits python::params {
   if $manage_python {
     include python
@@ -37,6 +38,7 @@ class python::pip::bootstrap (
         unless      => 'which pip3',
         path        => $python::params::pip_lookup_path,
         require     => Package['python3'],
+        provider    => $exec_provider,
       }
       # puppet is opinionated about the pip command name
       file { 'pip3-python':
@@ -52,6 +54,7 @@ class python::pip::bootstrap (
         unless      => 'which pip',
         path        => $python::params::pip_lookup_path,
         require     => Package['python'],
+        provider    => $exec_provider,
       }
       # puppet is opinionated about the pip command name
       file { 'pip-python':


### PR DESCRIPTION
#### Pull Request (PR) description
Use shell to exec pip commands by default

#### This Pull Request (PR) fixes the following issues
Sometimes Puppet will auto-select the POSIX provider to run exec resources. This will use the shell provider by default for pip execs where it matters. Needed for pipes and the bang operator.