### PR TITLE
missing rake command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN bundle install --without system_tests development release --path=${BUNDLE_PA
 COPY . .
 
 RUN bundle install
-RUN bundle exec release_checks
+RUN bundle exec rake release_checks
 
 # Container should not saved
 RUN exit 1


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Dockerfile failed to build as it was missing `rake` inside the `bundle exec`

#### This Pull Request (PR) fixes the following issues
Dockerfile build failed with following error:
```
Step 10/11 : RUN bundle exec release_checks
 ---> Running in ea81d27199df
bundler: command not found: release_checks
Install missing gem executables with `bundle install`
The command '/bin/sh -c bundle exec release_checks' returned a non-zero code: 127```
