### PR TITLE
Remove resource collector overriding pip_provider

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -293,10 +293,6 @@ class python::install {
         category => $pip_category,
       }
 
-      Python::Pip <| |> {
-        pip_provider => $pip_provider,
-      }
-
       Package <| title == 'virtualenv' |> {
         name => $virtualenv_package,
       }


### PR DESCRIPTION
#### Pull Request (PR) description
Remove resource collector overriding `pip_provider` parameter in `Python::Pip`

#### This Pull Request (PR) fixes the following issues
Fixes #505 

There seems to be an unrelated acceptance test failing locally for me (it's failing on master as well):
```
Failures:

  1) python class default parameters works with ensure=>latest for package with underscore in its name
     Failure/Error: apply_manifest(pp, catch_failures: true)
     Beaker::Host::CommandFailure:
       Host 'debian9-64-1' exited with 6 running:
        puppet apply --verbose --detailed-exitcodes /tmp/apply_manifest.pp.si5Ebi
       Last 10 lines of output were:
       	Info: Applying configuration version '1571415656'
       	Notice: /Stage[main]/Main/Python::Virtualenv[venv]/File[/opt/venv4]/ensure: created
       	Notice: /Stage[main]/Main/Python::Virtualenv[venv]/Exec[python_virtualenv_/opt/venv4]/returns: executed successfully
       	Notice: /Stage[main]/Main/Python::Pip[Randomized_Requests]/Exec[pip_install_Randomized_Requests]/returns: DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
       	Notice: /Stage[main]/Main/Python::Pip[Randomized_Requests]/Exec[pip_install_Randomized_Requests]/returns: ERROR: Could not find a version that satisfies the requirement Randomized_Requests (from versions: none)
       	Notice: /Stage[main]/Main/Python::Pip[Randomized_Requests]/Exec[pip_install_Randomized_Requests]/returns: ERROR: No matching distribution found for Randomized_Requests
       	Error: '/opt/venv4/bin/pip --log /opt/venv4/pip.log install --upgrade     Randomized_Requests' returned 1 instead of one of [0]
       	Error: /Stage[main]/Main/Python::Pip[Randomized_Requests]/Exec[pip_install_Randomized_Requests]/returns: change from 'notrun' to ['0'] failed: '/opt/venv4/bin/pip --log /opt/venv4/pip.log install --upgrade     Randomized_Requests' returned 1 instead of one of [0]
       	Info: Class[Main]: Unscheduling all events on Class[Main]
       	Notice: Applied catalog in 4.40 seconds
```