### PR TITLE
Fixes for virtualenv_version fact when virtualenv > 20.x

### DIFF
--- a/lib/facter/virtualenv_version.rb
+++ b/lib/facter/virtualenv_version.rb
@@ -3,7 +3,7 @@
 Facter.add('virtualenv_version') do
   setcode do
     if Facter::Util::Resolution.which('virtualenv')
-      Facter::Util::Resolution.exec('virtualenv --version 2>&1').match(%r{^(\d+\.\d+\.?\d*).*$})[0]
+      Facter::Util::Resolution.exec('virtualenv --version 2>&1').match(%r{(\d+\.\d+\.?\d*).*$})[1]
     end
   end
 end

--- a/spec/unit/facter/virtualenv_version_spec.rb
+++ b/spec/unit/facter/virtualenv_version_spec.rb
@@ -5,19 +5,44 @@ describe Facter::Util::Fact do
     Facter.clear
   end
 
-  let(:virtualenv_version_output) do
+  let(:virtualenv_old_version_output) do
     <<-EOS
 12.0.7
 EOS
   end
 
-  describe 'virtualenv_version' do
+  let(:virtualenv_new_version_output) do
+    <<-EOS
+virtualenv 20.0.17 from /opt/python/lib/python3.5/site-packages/virtualenv/__init__.py
+EOS
+  end
+
+  describe 'virtualenv_version old' do
     context 'returns virtualenv version when virtualenv present' do
       it do
         Facter::Util::Resolution.stubs(:exec)
         Facter::Util::Resolution.expects(:which).with('virtualenv').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('virtualenv --version 2>&1').returns(virtualenv_version_output)
+        Facter::Util::Resolution.expects(:exec).with('virtualenv --version 2>&1').returns(virtualenv_old_version_output)
         expect(Facter.value(:virtualenv_version)).to eq('12.0.7')
+      end
+    end
+
+    context 'returns nil when virtualenv not present' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with('virtualenv').returns(false)
+        expect(Facter.value(:virtualenv_version)).to eq(nil)
+      end
+    end
+  end
+
+  describe 'virtualenv_version new' do
+    context 'returns virtualenv version when virtualenv present' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with('virtualenv').returns(true)
+        Facter::Util::Resolution.expects(:exec).with('virtualenv --version 2>&1').returns(virtualenv_new_version_output)
+        expect(Facter.value(:virtualenv_version)).to eq('20.0.17')
       end
     end
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
This should fix issue #534 I've tested locally with success. I've tested against Virtualenv 20.0.4 and 16.7.9. 
The output from the fact is only the version number as was previously the case.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Fixes #534 
-->
