### PR TITLE
CentOS: Fix ordering dependency

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -243,6 +243,7 @@ class python::install {
             if $python::use_epel == true {
               include 'epel'
               Class['epel'] -> Package['pip']
+              Class['epel'] -> Package['python']
             }
           }
           if ($venv_ensure != 'absent') and ($facts['os']['release']['full'] =~ /^6/) {


### PR DESCRIPTION
The python package resource should always be executed after the epel
repository because python could come from that. epel has python34 and
python36.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
