### PR TITLE
fix site-packages parameter for focal fossa

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -97,11 +97,18 @@ define python::virtualenv (
     if (( versioncmp($_virtualenv_version,'1.7') > 0 ) and ( $systempkgs == true )) {
       $system_pkgs_flag = '--system-site-packages'
     } elsif (( versioncmp($_virtualenv_version,'1.7') < 0 ) and ( $systempkgs == false )) {
-      $system_pkgs_flag = '--no-site-packages'
+      if $facts['os']['release']['full'] == '20.04' {
+        $system_pkgs_flag = ''
+      } else {
+        $system_pkgs_flag = '--no-site-packages'
+      }
     } else {
       $system_pkgs_flag = $systempkgs ? {
         true    => '--system-site-packages',
-        false   => '--no-site-packages',
+        false   => $facts['os']['release']['full'] ? {
+          '20.04' => '',
+          default => '--no-site-packages'
+        },
         default => fail('Invalid value for systempkgs. Boolean value is expected')
       }
     }


### PR DESCRIPTION
#### Pull Request (PR) description
On Ubuntu 20.04 there is no parameter `--no-site-packages` for `virtualenv` binary anymore. The `--system-site-packages` stays the same.

#### This Pull Request (PR) fixes the following issues
Fixes '--no-site-packages' parameter on Ubuntu Focal Fossa

```
root@6e6956e915f1:/# grep -i focal /etc/os-release 
VERSION="20.04 LTS (Focal Fossa)"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

```
root@6e6956e915f1:/# virtualenv --version
virtualenv 20.0.17 from /usr/lib/python3/dist-packages/virtualenv/__init__.py
```

```
root@6e6956e915f1:/# virtualenv --help | grep 'no-site-packages'
root@6e6956e915f1:/# 
```

```
root@6e6956e915f1:/# virtualenv --help | grep '^[\ -]*system-site-packages'
  --system-site-packages        give the virtual environment access to the system site-packages dir (default: False)
```