### PR TITLE
Convert unit tests to rspec rather than 'mocha'

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,7 +7,5 @@
     - set: debian8-64
     - set: debian9-64
     - set: centos7-64
-spec/spec_helper.rb:
-  mock_with: ':mocha'
 spec/spec_helper_acceptance.rb:
   unmanaged: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,6 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
 
-RSpec.configure do |c|
-  c.mock_with :mocha
-end
-
 # puppetlabs_spec_helper will set up coverage if the env variable is set.
 # We want to do this if lib exists and it hasn't been explicitly set.
 ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../../lib', __FILE__))

--- a/spec/unit/facter/pip_version_spec.rb
+++ b/spec/unit/facter/pip_version_spec.rb
@@ -14,17 +14,15 @@ EOS
   describe 'pip_version' do
     context 'returns pip version when pip present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('pip').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('pip --version 2>&1').returns(pip_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('pip').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('pip --version 2>&1').and_return(pip_version_output)
         expect(Facter.value(:pip_version)).to eq('6.0.6')
       end
     end
 
     context 'returns nil when pip not present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('pip').returns(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('pip').and_return(false)
         expect(Facter.value(:pip_version)).to eq(nil)
       end
     end

--- a/spec/unit/facter/python_release_spec.rb
+++ b/spec/unit/facter/python_release_spec.rb
@@ -19,17 +19,16 @@ EOS
   describe 'python_release' do
     context 'returns Python release when `python` present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python -V 2>&1').returns(python2_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -V 2>&1').and_return(python2_version_output)
         expect(Facter.value(:python_release)).to eq('2.7')
       end
     end
 
     context 'returns nil when `python` not present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(false)
+        allow(Facter::Util::Resolution).to receive(:exec).and_return(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(false)
         expect(Facter.value(:python_release)).to eq(nil)
       end
     end
@@ -38,39 +37,35 @@ EOS
   describe 'python2_release' do
     context 'returns Python 2 release when `python` is present and Python 2' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python -V 2>&1').returns(python2_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -V 2>&1').and_return(python2_version_output)
         expect(Facter.value(:python2_release)).to eq('2.7')
       end
     end
 
     context 'returns Python 2 release when `python` is Python 3 and `python2` is present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python -V 2>&1').returns(python3_version_output)
-        Facter::Util::Resolution.expects(:which).with('python2').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python2 -V 2>&1').returns(python2_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -V 2>&1').and_return(python3_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python2').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python2 -V 2>&1').and_return(python2_version_output)
         expect(Facter.value(:python2_release)).to eq('2.7')
       end
     end
 
     context 'returns nil when `python` is Python 3 and `python2` is absent' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python -V 2>&1').returns(python3_version_output)
-        Facter::Util::Resolution.expects(:which).with('python2').returns(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -V 2>&1').and_return(python3_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python2').and_return(false)
         expect(Facter.value(:python2_release)).to eq(nil)
       end
     end
 
     context 'returns nil when `python2` and `python` are absent' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(false)
-        Facter::Util::Resolution.expects(:which).with('python2').returns(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python2').and_return(false)
         expect(Facter.value(:python2_release)).to eq(nil)
       end
     end
@@ -79,17 +74,15 @@ EOS
   describe 'python3_release' do
     context 'returns Python 3 release when `python3` present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python3').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python3 -V 2>&1').returns(python3_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python3').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python3 -V 2>&1').and_return(python3_version_output)
         expect(Facter.value(:python3_release)).to eq('3.3')
       end
     end
 
     context 'returns nil when `python3` not present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python3').returns(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python3').and_return(false)
         expect(Facter.value(:python3_release)).to eq(nil)
       end
     end

--- a/spec/unit/facter/python_version_spec.rb
+++ b/spec/unit/facter/python_version_spec.rb
@@ -19,17 +19,15 @@ EOS
   describe 'python_version' do
     context 'returns Python version when `python` present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python -V 2>&1').returns(python2_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -V 2>&1').and_return(python2_version_output)
         expect(Facter.value(:python_version)).to eq('2.7.9')
       end
     end
 
     context 'returns nil when `python` not present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(false)
         expect(Facter.value(:python_version)).to eq(nil)
       end
     end
@@ -38,39 +36,35 @@ EOS
   describe 'python2_version' do
     context 'returns Python 2 version when `python` is present and Python 2' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python -V 2>&1').returns(python2_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -V 2>&1').and_return(python2_version_output)
         expect(Facter.value(:python2_version)).to eq('2.7.9')
       end
     end
 
     context 'returns Python 2 version when `python` is Python 3 and `python2` is present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python -V 2>&1').returns(python3_version_output)
-        Facter::Util::Resolution.expects(:which).with('python2').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python2 -V 2>&1').returns(python2_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -V 2>&1').and_return(python3_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python2').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python2 -V 2>&1').and_return(python2_version_output)
         expect(Facter.value(:python2_version)).to eq('2.7.9')
       end
     end
 
     context 'returns nil when `python` is Python 3 and `python2` is absent' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python -V 2>&1').returns(python3_version_output)
-        Facter::Util::Resolution.expects(:which).with('python2').returns(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -V 2>&1').and_return(python3_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python2').and_return(false)
         expect(Facter.value(:python2_version)).to eq(nil)
       end
     end
 
     context 'returns nil when `python2` and `python` are absent' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python').returns(false)
-        Facter::Util::Resolution.expects(:which).with('python2').returns(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python2').and_return(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(false)
         expect(Facter.value(:python2_version)).to eq(nil)
       end
     end
@@ -79,17 +73,15 @@ EOS
   describe 'python3_version' do
     context 'returns Python 3 version when `python3` present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python3').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('python3 -V 2>&1').returns(python3_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('python3').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python3 -V 2>&1').and_return(python3_version_output)
         expect(Facter.value(:python3_version)).to eq('3.3.0')
       end
     end
 
     context 'returns nil when `python3` not present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('python3').returns(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python3').and_return(false)
         expect(Facter.value(:python3_version)).to eq(nil)
       end
     end

--- a/spec/unit/facter/virtualenv_version_spec.rb
+++ b/spec/unit/facter/virtualenv_version_spec.rb
@@ -20,17 +20,15 @@ EOS
   describe 'virtualenv_version old' do
     context 'returns virtualenv version when virtualenv present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('virtualenv').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('virtualenv --version 2>&1').returns(virtualenv_old_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('virtualenv').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('virtualenv --version 2>&1').and_return(virtualenv_old_version_output)
         expect(Facter.value(:virtualenv_version)).to eq('12.0.7')
       end
     end
 
     context 'returns nil when virtualenv not present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('virtualenv').returns(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('virtualenv').and_return(false)
         expect(Facter.value(:virtualenv_version)).to eq(nil)
       end
     end
@@ -39,18 +37,9 @@ EOS
   describe 'virtualenv_version new' do
     context 'returns virtualenv version when virtualenv present' do
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('virtualenv').returns(true)
-        Facter::Util::Resolution.expects(:exec).with('virtualenv --version 2>&1').returns(virtualenv_new_version_output)
+        allow(Facter::Util::Resolution).to receive(:which).with('virtualenv').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('virtualenv --version 2>&1').and_return(virtualenv_new_version_output)
         expect(Facter.value(:virtualenv_version)).to eq('20.0.17')
-      end
-    end
-
-    context 'returns nil when virtualenv not present' do
-      it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with('virtualenv').returns(false)
-        expect(Facter.value(:virtualenv_version)).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
Using rspec mocks is preferred over mocha, so update the testsuite to use rspec mocks instead.

#### This Pull Request (PR) fixes the following issues
Fixes #432 