### PR TITLE
Update virtualenv_version.rb

### DIFF
--- a/lib/facter/virtualenv_version.rb
+++ b/lib/facter/virtualenv_version.rb
@@ -3,7 +3,7 @@
 Facter.add('virtualenv_version') do
   setcode do
     if Facter::Util::Resolution.which('virtualenv')
-      Facter::Util::Resolution.exec('virtualenv --version 2>&1').match(%r{(\d+\.\d+\.?\d*).*$})[1]
+      Facter::Util::Resolution.exec('virtualenv --version 2>&1').match(%r{(\d+\.\d+\.?\d*).*$})[0]
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
This value should be a 0, since the previous change removed the ^ at the beginning of the regex, using a 1 index points to the word "from" in the string returned by `virtualenv --version` instead of the version number which occupies index 0 of the regex match.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Fixes #534
-->
