### PR TITLE
CentOS 6: Enable acceptance tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -6,6 +6,7 @@
     - set: ubuntu1804-64
     - set: debian8-64
     - set: debian9-64
+    - set: centos6-64
     - set: centos7-64
 spec/spec_helper_acceptance.rb:
   unmanaged: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,14 @@ jobs:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
+    env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos6-64 CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos6-64 CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
     env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos7-64 CHECK=beaker
     services: docker
   - rvm: 2.5.3


### PR DESCRIPTION
our metadata.json claims to support CentOS 6. In that case we should
also test on it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
