### PR TITLE
Use Python 3 for virtualenv tests

### DIFF
--- a/spec/acceptance/virtualenv_spec.rb
+++ b/spec/acceptance/virtualenv_spec.rb
@@ -5,11 +5,8 @@ describe 'python class' do
     # Using puppet_apply as a helper
     it 'works with no errors' do
       pp = <<-EOS
-      if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['major'] == '16.04' {
-        $version = '3'
-      } else {
-        $version = 'system'
-      }
+      $version = '3'
+
       class { 'python' :
         version    => $version,
         pip        => 'present',
@@ -19,6 +16,7 @@ describe 'python class' do
         ensure     => 'present',
         version    => $version,
         systempkgs => false,
+        distribute => false,
         venv_dir   => '/opt/venv',
       }
       -> python::pip { 'rpyc' :


### PR DESCRIPTION
#### Pull Request (PR) description
Python 2 has been deprecated, we should default to testing with Python 3

In commit 04ebe2d16d1d408f9c5d049aaa0426dce1c7bbe2, distribute was added
as an option to be set to false if setting up a python3 virtualenv.
Therefore, set distribute to false because we have defaulted to py3.