### PR TITLE
Rework determination of virtualenv site-packages flags for v20

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -86,24 +86,27 @@ define python::virtualenv (
       }
     }
 
-    # Virtualenv versions prior to 1.7 do not support the
-    # --system-site-packages flag, default off for prior versions
-    # Prior to version 1.7 the default was equal to --system-site-packages
-    # and the flag --no-site-packages had to be passed to do the opposite
+    # Virtualenv handling of site packages has changed over time, both its
+    # default and the flags to control it. See inline comments for details.
     $_virtualenv_version = getvar('virtualenv_version') ? {
       /.*/ => getvar('virtualenv_version'),
       default => '',
     }
-    if (( versioncmp($_virtualenv_version,'1.7') > 0 ) and ( $systempkgs == true )) {
-      $system_pkgs_flag = '--system-site-packages'
-    } elsif (( versioncmp($_virtualenv_version,'1.7') < 0 ) and ( $systempkgs == false )) {
-      $system_pkgs_flag = '--no-site-packages'
-    } else {
-      $system_pkgs_flag = $systempkgs ? {
-        true    => '--system-site-packages',
-        false   => '--no-site-packages',
-        default => fail('Invalid value for systempkgs. Boolean value is expected')
-      }
+    $system_pkgs_flag = $systempkgs ? {
+      # --system-site-packages was introducd in 1.7, and --no-site-packages
+      # became the default
+      true    => versioncmp($_virtualenv_version,'1.7') > 0 ? {
+        true  => '--system-site-packages',
+        # Rely on default prior to 1.7
+        false => '',
+      },
+      # --no-site-packages was removed in 20.0
+      false   => versioncmp($_virtualenv_version,'20') < 0 ? {
+        true  => '--no-site-packages',
+        # Rely on default after 20.0
+        false => '',
+      },
+      default => fail('Invalid value for systempkgs. Boolean value is expected')
     }
 
     $distribute_pkg = $distribute ? {


### PR DESCRIPTION
`virtualenv` 20.0 removed `--no-site-packages` so we cannot pass that on that version. This means we have three version scenarios to cope with:

* `< 1.7`: site packages installed by default, with `--no-site-packages` to opt out

* `1.7` - `20.0`: `--no-site-packages` present and default, `--system-site-packages` to opt back in

* `> 20.0`: no site packages by default, `--system-site-packages` to opt back in

This PR aims to add support for the last of these, so that all three are supported.

This was mentioned at https://github.com/voxpupuli/puppet-python/issues/534#issuecomment-585869365 and I've hit this myself (on Fedora 33, where this patch fixes it for me).

Meta: I've not yet added any tests; I'm not sure how to do that, but if you can point me in the right direction I'm happy to give it a go.