### PR TITLE
Add python-venv installation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -27,12 +27,12 @@
 
 ### Data types
 
-* [`Python::Loglevel`](#pythonloglevel): A version type to match all valid loglevels for python
-* [`Python::Package::Ensure`](#pythonpackageensure): A version type to match all valid package ensures for python
-* [`Python::Provider`](#pythonprovider): A version type to match all valid provider for python
-* [`Python::Umask`](#pythonumask): A version type to match valid umask for python
+* [`Python::Loglevel`](#pythonloglevel): Match all valid loglevels for python
+* [`Python::Package::Ensure`](#pythonpackageensure): Match all valid package ensures for python
+* [`Python::Provider`](#pythonprovider): Match all valid provider for python
+* [`Python::Umask`](#pythonumask): Match valid umask for python
 * [`Python::Venv::PipVersion`](#pythonvenvpipversion): A version type to ensure a specific Pip version in a virtual env.
-* [`Python::Version`](#pythonversion): A version type to match all valid versions for python
+* [`Python::Version`](#pythonversion): Match all valid versions for python
 
 ## Classes
 
@@ -77,8 +77,11 @@ The following parameters are available in the `python` class:
 * [`use_epel`](#use_epel)
 * [`manage_scl`](#manage_scl)
 * [`umask`](#umask)
+* [`manage_gunicorn`](#manage_gunicorn)
 * [`manage_python_package`](#manage_python_package)
+* [`manage_venv_package`](#manage_venv_package)
 * [`manage_pip_package`](#manage_pip_package)
+* [`venv`](#venv)
 * [`gunicorn_package_name`](#gunicorn_package_name)
 * [`python_pips`](#python_pips)
 * [`python_pyvenvs`](#python_pyvenvs)
@@ -175,21 +178,43 @@ The default umask for invoked exec calls.
 
 Default value: ``undef``
 
+##### <a name="manage_gunicorn"></a>`manage_gunicorn`
+
+manage the state for package gunicorn
+
+Default value: `$python::params::manage_gunicorn`
+
 ##### <a name="manage_python_package"></a>`manage_python_package`
 
 Data type: `Boolean`
 
-
+manage the state for package python
 
 Default value: `$python::params::manage_python_package`
+
+##### <a name="manage_venv_package"></a>`manage_venv_package`
+
+Data type: `Boolean`
+
+manage the state for package venv
+
+Default value: `$python::params::manage_venv_package`
 
 ##### <a name="manage_pip_package"></a>`manage_pip_package`
 
 Data type: `Boolean`
 
-
+manage the state for package pip
 
 Default value: `$python::params::manage_pip_package`
+
+##### <a name="venv"></a>`venv`
+
+Data type: `Python::Package::Ensure`
+
+
+
+Default value: `$python::params::venv`
 
 ##### <a name="gunicorn_package_name"></a>`gunicorn_package_name`
 
@@ -1112,7 +1137,7 @@ Default value: `1800`
 
 ### <a name="pythonloglevel"></a>`Python::Loglevel`
 
-A version type to match all valid loglevels for python
+Match all valid loglevels for python
 
 Alias of
 
@@ -1122,7 +1147,7 @@ Enum['debug', 'info', 'warning', 'error', 'critical']
 
 ### <a name="pythonpackageensure"></a>`Python::Package::Ensure`
 
-A version type to match all valid package ensures for python
+Match all valid package ensures for python
 
 Alias of
 
@@ -1132,7 +1157,7 @@ Enum['absent', 'present', 'latest']
 
 ### <a name="pythonprovider"></a>`Python::Provider`
 
-A version type to match all valid provider for python
+Match all valid provider for python
 
 Alias of
 
@@ -1142,7 +1167,7 @@ Enum['pip', 'scl', 'rhscl', 'anaconda', '']
 
 ### <a name="pythonumask"></a>`Python::Umask`
 
-A version type to match valid umask for python
+Match valid umask for python
 
 Alias of
 
@@ -1162,7 +1187,7 @@ Pattern[/^(<|>|<=|>=|==) [0-9]*(\.[0-9]+)*$/, /\Alatest\Z/]
 
 ### <a name="pythonversion"></a>`Python::Version`
 
-A version type to match all valid versions for python
+Match all valid versions for python
 
 Alias of
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,10 @@
 # @param use_epel to determine if the epel class is used.
 # @param manage_scl Whether to manage core SCL packages or not.
 # @param umask The default umask for invoked exec calls.
+# @param manage_gunicorn manage the state for package gunicorn
+# @param manage_python_package manage the state for package python
+# @param manage_venv_package manage the state for package venv
+# @param manage_pip_package manage the state for package pip
 #
 # @example install python from system python
 #   class { 'python':
@@ -37,9 +41,11 @@ class python (
   Python::Version            $version                     = '3',
   Python::Package::Ensure    $pip                         = $python::params::pip,
   Python::Package::Ensure    $dev                         = $python::params::dev,
+  Python::Package::Ensure    $venv                        = $python::params::venv,
   Python::Package::Ensure    $gunicorn                    = $python::params::gunicorn,
   Boolean                    $manage_gunicorn             = $python::params::manage_gunicorn,
   Boolean                    $manage_python_package       = $python::params::manage_python_package,
+  Boolean                    $manage_venv_package         = $python::params::manage_venv_package,
   Boolean                    $manage_pip_package          = $python::params::manage_pip_package,
   String[1]                  $gunicorn_package_name       = $python::params::gunicorn_package_name,
   Optional[Python::Provider] $provider                    = $python::params::provider,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,10 +13,11 @@ class python::params {
   $pip                         = 'present'
   $dev                         = 'absent'
   $virtualenv                  = 'absent'
+  $venv                        = 'absent'
   $gunicorn                    = 'absent'
   $manage_gunicorn             = true
   $manage_python_package       = true
-  $manage_virtualenv_package   = true
+  $manage_venv_package         = true
   $manage_pip_package          = true
   $provider                    = undef
   $valid_versions              = undef

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -44,14 +44,6 @@ define python::pyvenv (
     $python_version_parts      = split($python_version, '[.]')
     $normalized_python_version = sprintf('%s.%s', $python_version_parts[0], $python_version_parts[1])
 
-    # Debian splits the venv module into a seperate package
-    if ( $facts['os']['family'] == 'Debian') {
-      $python3_venv_package = "python${normalized_python_version}-venv"
-      ensure_packages($python3_venv_package)
-
-      Package[$python3_venv_package] -> File[$venv_dir]
-    }
-
     # pyvenv is deprecated since 3.6 and will be removed in 3.8
     if versioncmp($normalized_python_version, '3.6') >=0 {
       $virtualenv_cmd = "${python::exec_prefix}python${normalized_python_version} -m venv"
@@ -71,10 +63,11 @@ define python::pyvenv (
     }
 
     file { $venv_dir:
-      ensure => directory,
-      owner  => $owner,
-      group  => $group,
-      mode   => $mode,
+      ensure  => directory,
+      owner   => $owner,
+      group   => $group,
+      mode    => $mode,
+      require => Class['python::install'],
     }
 
     $pip_cmd = "${python::exec_prefix}${venv_dir}/bin/pip"

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -23,6 +23,7 @@ describe 'python class' do
         version    => '3',
         pip        => 'present',
         dev        => 'present',
+        venv       => 'present',
       }
       EOS
 

--- a/spec/acceptance/pyvenv_spec.rb
+++ b/spec/acceptance/pyvenv_spec.rb
@@ -10,6 +10,7 @@ describe 'python::pyvenv defined resource with python 3' do
       class { 'python':
         version => '3',
         dev     => 'present',
+        venv    => 'present',
       }
       user { 'agent':
         ensure         => 'present',
@@ -42,6 +43,7 @@ describe 'python::pyvenv defined resource with python 3' do
       class { 'python':
         version => '3',
         dev     => 'present',
+        venv    => 'present',
       }
       user { 'agent':
         ensure         => 'present',
@@ -82,6 +84,7 @@ describe 'python::pyvenv defined resource with python 3' do
       class { 'python':
         version => '3',
         dev     => 'present',
+        venv    => 'present',
       }
       user { 'agent':
         ensure         => 'present',
@@ -119,6 +122,7 @@ describe 'python::pyvenv defined resource with python 3' do
       class { 'python':
         version => '3',
         dev     => 'present',
+        venv    => 'present',
       }
       user { 'agent':
         ensure         => 'present',
@@ -156,6 +160,7 @@ describe 'python::pyvenv defined resource with python 3' do
       class { 'python':
         version => '3',
         dev     => 'present',
+        venv    => 'present',
       }
       user { 'agent':
         ensure         => 'present',

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -17,19 +17,39 @@ describe 'python' do
         it { is_expected.to contain_class('python::config') }
         it { is_expected.to contain_package('python') }
         it { is_expected.to contain_package('pip') }
+
+        it { is_expected.to contain_package('python-venv') } unless facts[:os]['name'] == 'CentOS'
       end
 
       context 'without managing things' do
         let :params do
           {
             manage_python_package: false,
-            manage_pip_package: false
+            manage_pip_package: false,
+            manage_venv_package: false
           }
         end
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.not_to contain_package('python') }
         it { is_expected.not_to contain_package('pip') }
+        it { is_expected.not_to contain_package('python-venv') }
+      end
+
+      context 'with packages present' do
+        let :params do
+          {
+            manage_pip_package: true,
+            manage_venv_package: true,
+            pip: 'present',
+            venv: 'present'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('pip').with(ensure: 'present') }
+
+        it { is_expected.to contain_package('python-venv').with(ensure: 'present') } unless facts[:os]['name'] == 'CentOS'
       end
 
       case facts[:os]['family']

--- a/spec/defines/pyvenv_spec.rb
+++ b/spec/defines/pyvenv_spec.rb
@@ -18,10 +18,8 @@ describe 'python::pyvenv', type: :define do
       end
 
       context 'with default parameters' do
-        it { is_expected.to contain_file('/opt/env') }
+        it { is_expected.to contain_file('/opt/env').that_requires('Class[python::install]') }
         it { is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear  /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools') }
-
-        it { is_expected.to contain_package('python3.5-venv').that_comes_before('File[/opt/env]') } if %w[xenial bionic cosmic disco stretch buster].include?(facts[:lsbdistcodename])
       end
 
       describe 'when ensure' do

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -1,3 +1,3 @@
-# @summary A version type to match all valid loglevels for python
+# @summary Match all valid loglevels for python
 #
 type Python::Loglevel = Enum['debug', 'info', 'warning', 'error', 'critical']

--- a/types/package/ensure.pp
+++ b/types/package/ensure.pp
@@ -1,3 +1,3 @@
-# @summary A version type to match all valid package ensures for python
+# @summary Match all valid package ensures for python
 #
 type Python::Package::Ensure = Enum['absent', 'present', 'latest']

--- a/types/provider.pp
+++ b/types/provider.pp
@@ -1,3 +1,3 @@
-# @summary A version type to match all valid provider for python
+# @summary Match all valid provider for python
 #
 type Python::Provider = Enum['pip', 'scl', 'rhscl', 'anaconda', '']

--- a/types/umask.pp
+++ b/types/umask.pp
@@ -1,3 +1,3 @@
-# @summary A version type to match valid umask for python
+# @summary Match valid umask for python
 #
 type Python::Umask = Pattern[/[0-7]{1,4}/]

--- a/types/version.pp
+++ b/types/version.pp
@@ -1,4 +1,4 @@
-# @summary A version type to match all valid versions for python
+# @summary Match all valid versions for python
 #
 type Python::Version = Pattern[
   /\A(python)?[0-9](\.?[0-9])*/,


### PR DESCRIPTION
#### Pull Request (PR) description
If you use `python::pyvenv` you require the package `python-venv` (name differs on OSes). This has been missing.
