### PR TITLE
Fix python::virtualenv to allow virtualenv to not require absolute path

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -49,7 +49,7 @@ define python::virtualenv (
   Integer                               $timeout         = 1800,
   String                                $pip_args        = '',
   String                                $extra_pip_args  = '',
-  Optional[Stdlib::Absolutepath]        $virtualenv      = undef,
+  Optional[String[1]]                   $virtualenv      = undef,
 ) {
   include python
 

--- a/spec/defines/virtualenv_spec.rb
+++ b/spec/defines/virtualenv_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'python::virtualenv', type: :define do
+  on_supported_os.each do |os, facts|
+    next if os == 'gentoo-3-x86_64'
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+      let :title do
+        '/opt/env'
+      end
+
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/opt/env') }
+        it { is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('virtualenv --no-site-packages -p python /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install  --proxy=  --upgrade pip && /opt/env/bin/pip install  --proxy=  --upgrade distribute') }
+      end
+
+      context 'when virtualenv is defined' do
+        let(:params) {{ virtualenv: 'virtualenv-3' }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_exec('python_virtualenv_/opt/env').with_command(%r{virtualenv-3 --no-site-packages -p python .+}) }
+      end
+
+      describe 'when ensure' do
+        context 'is absent' do
+          let :params do
+            {
+              ensure: 'absent'
+            }
+          end
+
+          it {
+            is_expected.to contain_file('/opt/env').with_ensure('absent').with_purge(true)
+          }
+        end
+      end
+    end # context
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

I maintain several modules where I might do something like `virtualenv => 'virtualenv-3'` and that works just fine and doesn't require me to know the full path on each OS.  Also the default value if undef is just `virtualenv` so doesn't make sense to require the non-default values be more restrictive than the default.