### PR TITLE
Support Puppet 7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 5.5.8 < 8.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
#### Pull Request (PR) description

This allows using Puppet 7 with this module when strict dependency checking is enabled.

#### This Pull Request (PR) fixes the following issues

Without this change Kafo installers such as Foreman's Kafo installer will fail with this error message:

```
Puppet 7.5.0 does not meet requirements for puppet-python (>= 5.5.8 < 7.0.0)
Cannot continue due to incompatible version of Puppet.
Use --skip-puppet-version-check to disable this check.
```