### PR TITLE
Use $real_pkgname for pip uninstall command

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -220,7 +220,7 @@ define python::pip (
 
       default: {
         # Anti-action, uninstall.
-        $command        = "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag} ${name}"
+        $command        = "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag} ${real_pkgname}"
         $unless_command = "! ${pip_env} list | grep -i -e '${grep_regex}'"
       }
     }

--- a/spec/acceptance/pip_spec.rb
+++ b/spec/acceptance/pip_spec.rb
@@ -9,9 +9,17 @@ describe 'python::pip defined resource' do
         dev     => 'present',
       }
 
+      python::pyvenv { '/opt/test-venv':
+        ensure      => 'present',
+        systempkgs  => false,
+        mode        => '0755',
+        pip_version => '<= 20.3.4',
+      }
+
       python::pip { 'agent package':
-        pkgname => 'agent',
-        ensure  => '0.1.2',
+        virtualenv => '/opt/test-venv',
+        pkgname    => 'agent',
+        ensure     => '0.1.2',
       }
       PUPPET
 
@@ -20,7 +28,7 @@ describe 'python::pip defined resource' do
     end
   end
 
-  describe command('/usr/bin/pip list') do
+  describe command('/opt/test-venv/bin/pip list') do
     its(:exit_status) { is_expected.to eq 0 }
     its(:stdout) { is_expected.to match %r{agent.* 0\.1\.2} }
   end
@@ -33,25 +41,33 @@ describe 'python::pip defined resource' do
         dev     => 'present',
       }
 
-      python::pip { 'agent package install':
-        pkgname => 'agent',
-        ensure  => '0.1.2',
+      python::pyvenv { '/opt/test-venv':
+        ensure      => 'present',
+        systempkgs  => false,
+        mode        => '0755',
+        pip_version => '<= 20.3.4',
       }
 
-      python::pip { 'agent package uninstall':
-        pkgname => 'agent',
+      python::pip { 'agent package install':
+        ensure     => '0.1.2',
+        pkgname    => 'agent',
+        virtualenv => '/opt/test-venv',
+      }
+
+      python::pip { 'agent package uninstall custom pkgname':
         ensure  => 'absent',
+        pkgname => 'agent',
+        virtualenv => '/opt/test-venv',
         require => Python::Pip['agent package install'],
       }
 
       PUPPET
 
       apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
     end
   end
 
-  describe command('/usr/bin/pip list') do
+  describe command('/opt/test-venv/bin/pip list') do
     its(:exit_status) { is_expected.to eq 0 }
     its(:stdout) { is_expected.not_to match %r{agent.* 0\.1\.2} }
   end

--- a/spec/acceptance/pip_spec.rb
+++ b/spec/acceptance/pip_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper_acceptance'
+
+describe 'python::pip defined resource' do
+  context 'install package with custom name' do
+    it 'works with no errors' do
+      pp = <<-PUPPET
+      class { 'python':
+        version => '3',
+        dev     => 'present',
+      }
+
+      python::pip { 'agent package':
+        pkgname => 'agent'
+        ensure  => '0.1.2'
+      }
+      PUPPET
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+  end
+  describe command('/opt/agent/venv/bin/pip list') do
+    its(:exit_status) { is_expected.to eq 0 }
+    its(:stdout) { is_expected.to match %r{agent.* 0\.1\.2} }
+  end
+end
+

--- a/spec/acceptance/pip_spec.rb
+++ b/spec/acceptance/pip_spec.rb
@@ -17,6 +17,7 @@ describe 'python::pip defined resource' do
 
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
+    end
   end
 
   describe command('/usr/bin/pip list') do
@@ -47,6 +48,7 @@ describe 'python::pip defined resource' do
 
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
+    end
   end
 
   describe command('/usr/bin/pip list') do

--- a/spec/acceptance/pip_spec.rb
+++ b/spec/acceptance/pip_spec.rb
@@ -10,17 +10,48 @@ describe 'python::pip defined resource' do
       }
 
       python::pip { 'agent package':
-        pkgname => 'agent'
-        ensure  => '0.1.2'
+        pkgname => 'agent',
+        ensure  => '0.1.2',
       }
       PUPPET
 
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
   end
+
   describe command('/usr/bin/pip list') do
     its(:exit_status) { is_expected.to eq 0 }
     its(:stdout) { is_expected.to match %r{agent.* 0\.1\.2} }
+  end
+
+  context 'uninstall package with custom name' do
+    it 'works with no errors' do
+      pp = <<-PUPPET
+      class { 'python':
+        version => '3',
+        dev     => 'present',
+      }
+
+      python::pip { 'agent package install':
+        pkgname => 'agent',
+        ensure  => '0.1.2',
+      }
+
+      python::pip { 'agent package uninstall':
+        pkgname => 'agent',
+        ensure  => 'absent',
+        require => Python::Pip['agent package install'],
+      }
+
+      PUPPET
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+  end
+
+  describe command('/usr/bin/pip list') do
+    its(:exit_status) { is_expected.to eq 0 }
+    its(:stdout) { is_expected.not_to match %r{agent.* 0\.1\.2} }
   end
 end
 

--- a/spec/acceptance/pip_spec.rb
+++ b/spec/acceptance/pip_spec.rb
@@ -18,7 +18,7 @@ describe 'python::pip defined resource' do
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
   end
-  describe command('/opt/agent/venv/bin/pip list') do
+  describe command('/usr/bin/pip list') do
     its(:exit_status) { is_expected.to eq 0 }
     its(:stdout) { is_expected.to match %r{agent.* 0\.1\.2} }
   end

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -116,6 +116,14 @@ describe 'python::pip', type: :define do # rubocop:disable RSpec/MultipleDescrib
 
         it { is_expected.to contain_exec('pip_uninstall_rpyc').with_command(%r{uninstall.*rpyc$}) }
       end
+
+      context 'passes correct package name' do
+        let(:params) { { ensure: 'absent', 'pkgname': 'r-pyc' } }
+
+        it { is_expected.not_to contain_exec('pip_install_rpyc') }
+
+        it { is_expected.to contain_exec('pip_uninstall_rpyc').with_command(%r{uninstall.*r-pyc$}) }
+      end
     end
   end
 end


### PR DESCRIPTION
Fix #606

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Use $real_pkgname for pip uninstall command

#### This Pull Request (PR) fixes the following issues
Fixes #606 
