### PR TITLE
New function: any_puppet_to_python()

### DIFF
--- a/lib/puppet/functions/any_puppet_to_python.rb
+++ b/lib/puppet/functions/any_puppet_to_python.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# @summary
+#   Return the Python representation of the passed variable
+Puppet::Functions.create_function(:any_puppet_to_python) do
+  dispatch :any_puppet_to_python do
+    param 'Any', :value
+  end
+
+  # @param value
+  #   The value to be converted
+  #
+  # @return [String]
+  #   The String representation of value
+  def any_puppet_to_python(value)
+    case value
+    when true then 'True'
+    when false then 'False'
+    when :undef then 'None'
+    when Array then "[#{value.map { |x| any_puppet_to_python(x) }.join(', ')}]"
+    when Hash then "{#{value.map { |k, v| "#{any_puppet_to_python(k)}: #{any_puppet_to_python(v)}" }.join(', ')}}"
+    else value.inspect
+    end
+  end
+end

--- a/spec/acceptance/any_puppet_to_python_spec.rb
+++ b/spec/acceptance/any_puppet_to_python_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper_acceptance'
+
+describe 'any_puppet_to_python function' do
+  it 'works with no errors' do
+    pp = <<-EOS
+    class { 'python':
+      ensure  => 'present',
+      version => '3',
+    }
+
+    $var = {
+      1     => 2,
+      3     => [
+        5,
+        7,
+        'bar'
+      ],
+      'foo' => 11,
+    }
+    file { '/tmp/foo.py':
+      ensure  => file,
+      mode    => '0755',
+      content => inline_epp(@(PYTHON), { var => $var }),
+        <%- |Any $var| -%>
+        #!/usr/bin/env python3
+        var = <%= $var.any_puppet_to_python() %>
+        print(var[1] + var[3][1] + var["foo"])
+        print(var[3][2] * var[3][0])
+        | PYTHON
+    }
+    EOS
+
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+
+    expect(shell('/tmp/foo.py').stdout).to eq("20\nbarbarbarbarbar\n")
+  end
+end

--- a/spec/functions/any_puppet_to_python_spec.rb
+++ b/spec/functions/any_puppet_to_python_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'any_puppet_to_python' do
+  context 'with Array[Any]' do
+    it { is_expected.to run.with_params([]).and_return('[]') }
+    it { is_expected.to run.with_params([[[[], 1], '2'], 3]).and_return('[[[[], 1], "2"], 3]') }
+    it { is_expected.to run.with_params([42, 'foo', true, {}]).and_return('[42, "foo", True, {}]') }
+  end
+  context 'with Hash[Any]' do
+    it { is_expected.to run.with_params({}).and_return('{}') }
+    it { is_expected.to run.with_params({ '1' => { 2 => { '3' => {} } } }).and_return('{"1": {2: {"3": {}}}}') }
+    it { is_expected.to run.with_params({ 42 => 42, 'foo' => 'bar', '6 * 9' => { 'answer' => [42] } }).and_return('{42: 42, "foo": "bar", "6 * 9": {"answer": [42]}}') }
+  end
+  context 'with Boolean' do
+    it { is_expected.to run.with_params(true).and_return('True') }
+    it { is_expected.to run.with_params(false).and_return('False') }
+  end
+  context 'with String' do
+    it { is_expected.to run.with_params('').and_return('""') }
+    it { is_expected.to run.with_params('foo').and_return('"foo"') }
+    it { is_expected.to run.with_params("foo\nbar").and_return('"foo\nbar"') }
+  end
+  context 'with Undef' do
+    it { is_expected.to run.with_params(:undef).and_return('None') }
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

This function return a String representation of the value passed as
parameter.

The idea is to provide a helper function usable in epp templates when the configuration files we are managing are Python scripts, e.g. https://github.com/voxpupuli/puppet-puppetboard, https://github.com/opus-codium/puppet-taiga

#### This Pull Request (PR) fixes the following issues
n/a

#### Example usage

```epp
EMAIL_USE_TLS = <%= String($taiga::back::email_use_tls, '%T') %>
EMAIL_HOST = <%= if $taiga::back::email_host { String($taiga::back::email_host, '%p') } else { 'None' } %>
```

becomes:

```epp
EMAIL_USE_TLS = <%= any_puppet_to_python($taiga::back::email_use_tls) %>
EMAIL_HOST = <%= any_puppet_to_python($taiga::back::email_host) %>
```