### PR TITLE
Remove duplicate arguments in the pip install command

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -173,7 +173,7 @@ define python::pip (
   }
 
   $pip_install     = "${pip_env} --log ${log}/pip.log install"
-  $pip_common_args = "${pypi_index} ${proxy_flag} ${install_args} ${install_editable} ${source}"
+  $pip_common_args = "${pypi_index} ${proxy_flag} ${install_editable} ${source}"
 
   # Explicit version out of VCS when PIP supported URL is provided
   if $source =~ /^'(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp|git)(:\/\/).+'$/ {
@@ -195,7 +195,7 @@ define python::pip (
 
       'present': {
         # Whatever version is available.
-        $command        = "${pip_install} ${pip_common_args}"
+        $command        = "${pip_install} ${install_args} ${pip_common_args}"
         $unless_command = "${pip_env} list | grep -i -e '${grep_regex}'"
       }
 
@@ -214,7 +214,7 @@ define python::pip (
         $grep_regex_pkgname_with_dashes = "^${pkgname_with_dashes}=="
         $installed_version              = join( ["${pip_env} freeze --all", " | grep -i -e ${grep_regex_pkgname_with_dashes} | cut -d= -f3", " | tr -d '[:space:]'",])
 
-        $command        = "${pip_install} --upgrade ${pip_common_args}"
+        $command        = "${pip_install} --upgrade ${install_args} ${pip_common_args}"
         $unless_command = "[ \$(${latest_version}) = \$(${installed_version}) ]"
       }
 

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -68,7 +68,7 @@ describe 'python::pip', type: :define do
       context 'adds proxy to install command if proxy set' do
         let(:params) { { proxy: 'http://my.proxy:3128' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install  --proxy=http://my.proxy:3128   rpyc') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install   --proxy=http://my.proxy:3128  rpyc') }
       end
     end
 
@@ -81,7 +81,7 @@ describe 'python::pip', type: :define do
       context 'adds index to install command if index set' do
         let(:params) { { index: 'http://www.example.com/simple/' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install --index-url=http://www.example.com/simple/    rpyc') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install  --index-url=http://www.example.com/simple/   rpyc') }
       end
     end
 

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -94,6 +94,14 @@ describe 'python::pip', type: :define do
       end
     end
 
+    describe 'install_args as' do
+      context 'adds install_args to install command if install_args set' do
+        let(:params) { { install_args: '--pre' } }
+
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install --pre    rpyc') }
+      end
+    end
+
     describe 'install latest' do
       context 'does not use pip search in unless' do
         let(:params) { { ensure: 'latest' } }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

`${install_args}` is duplicated in the arguments given to the `pip install` command to be executed.
The duplication does not cause anything bad, but I think it is better to remove it.

#### This Pull Request (PR) fixes the following issues

None