### PR TITLE
Correct python::pip::environment parameter example

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -628,7 +628,7 @@ python::pip { 'cx_Oracle' :
   virtualenv    => '/var/www/project1',
   owner         => 'appuser',
   proxy         => 'http://proxy.domain.com:3128',
-  environment   => 'ORACLE_HOME=/usr/lib/oracle/11.2/client64',
+  environment   => ['ORACLE_HOME=/usr/lib/oracle/11.2/client64'],
   install_args  => '-e',
   timeout       => 1800,
 }

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -33,7 +33,7 @@
 #     virtualenv    => '/var/www/project1',
 #     owner         => 'appuser',
 #     proxy         => 'http://proxy.domain.com:3128',
-#     environment   => 'ORACLE_HOME=/usr/lib/oracle/11.2/client64',
+#     environment   => ['ORACLE_HOME=/usr/lib/oracle/11.2/client64'],
 #     install_args  => '-e',
 #     timeout       => 1800,
 #   }


### PR DESCRIPTION
#### Pull Request (PR) description

The example for `python::pip{'cx_Oracle':...}` used and invalid
environment parameter.