### PR TITLE
use legacy pip resolver for pip versions < 21.1 > 20.2.4

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -207,11 +207,18 @@ define python::pip (
       }
 
       'latest': {
+        $pip_version = $facts['pip_version']
+        if $pip_version and versioncmp($pip_version, '21.1') == -1 and versioncmp($pip_version, '20.2.4') == 1 {
+          $legacy_resolver = '--use-deprecated=legacy-resolver'
+        } else {
+          $legacy_resolver = ''
+        }
+
         # Unfortunately this is the smartest way of getting the latest available package version with pip as of now
         # Note: we DO need to repeat ourselves with "from version" in both grep and sed as on some systems pip returns
         # more than one line with paretheses.
         $latest_version = join( [
-            "${pip_install} ${pypi_index} ${pypi_extra_index} ${proxy_flag}",
+            "${pip_install} ${legacy_resolver} ${pypi_index} ${pypi_extra_index} ${proxy_flag}",
             " ${install_args} ${install_editable} ${real_pkgname}==notreallyaversion 2>&1",
             ' | grep -oP "\(from versions: .*\)" | sed -E "s/\(from versions: (.*?, )*(.*)\)/\2/g"',
             ' | tr -d "[:space:]"',

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -20,7 +20,8 @@ describe 'python::pip', type: :define do
         operatingsystem: 'Debian',
         operatingsystemrelease: '6',
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        concat_basedir: '/dne'
+        concat_basedir: '/dne',
+        pip_version: '18.1'
       }
     end
 
@@ -126,6 +127,12 @@ describe 'python::pip', type: :define do
     end
 
     describe 'install latest' do
+      context 'does not use legacy resolver in unless' do
+        let(:params) { { ensure: 'latest' } }
+
+        it { is_expected.not_to contain_exec('pip_install_rpyc').with_unless(%r{--use-deprecated=legacy-resolver}) }
+      end
+
       context 'does not use pip search in unless' do
         let(:params) { { ensure: 'latest' } }
 
@@ -155,6 +162,35 @@ describe 'python::pip', type: :define do
         it { is_expected.not_to contain_exec('pip_install_rpyc') }
 
         it { is_expected.to contain_exec('pip_uninstall_rpyc').with_command(%r{uninstall.*r-pyc$}) }
+      end
+    end
+  end
+
+  context 'on Debian OS with pip_version 20.3.4' do
+    let :facts do
+      {
+        id: 'root',
+        kernel: 'Linux',
+        lsbdistcodename: 'buster',
+        os: {
+          family: 'Debian',
+          release: { major: '10' },
+        },
+        osfamily: 'Debian',
+        operatingsystem: 'Debian',
+        operatingsystemrelease: '10.12',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        concat_basedir: '/dne',
+        pip_version: '20.3.4'
+      }
+    end
+
+    describe 'install latest' do
+      context 'with legacy resolver in unless cmd' do
+        let(:params) { { ensure: 'latest' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_unless(%r{--use-deprecated=legacy-resolver}) }
       end
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR adds the flag `--use-deprecated=legacy-resolver` to pip install commands, if pip version is below 21.1 and higher than 20.2.4

#### This Pull Request (PR) fixes the following issues
Fixes #638