### PR TITLE
Add extra_index parameter to python::pip

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -685,6 +685,7 @@ The following parameters are available in the `python::pip` defined type:
 * [`owner`](#owner)
 * [`group`](#group)
 * [`index`](#index)
+* [`extra_index`](#extra_index)
 * [`proxy`](#proxy)
 * [`editable`](#editable)
 * [`environment`](#environment)
@@ -763,6 +764,14 @@ Default value: `getvar('python::params::group')`
 Data type: `Variant[Boolean,String[1]]`
 
 Base URL of Python package index.
+
+Default value: ``false``
+
+##### <a name="extra_index"></a>`extra_index`
+
+Data type: `Variant[Boolean,String[1]]`
+
+Base URL of extra Python package index.
 
 Default value: ``false``
 

--- a/spec/acceptance/pip_spec.rb
+++ b/spec/acceptance/pip_spec.rb
@@ -31,6 +31,7 @@ describe 'python::pip defined resource' do
   end
 
   # rubocop:disable RSpec/RepeatedExampleGroupDescription
+  # rubocop:disable RSpec/RepeatedExampleGroupBody
   describe command('/opt/test-venv/bin/pip list') do
     its(:exit_status) { is_expected.to eq 0 }
     its(:stdout) { is_expected.to match %r{agent.* 0\.1\.2} }
@@ -74,5 +75,40 @@ describe 'python::pip defined resource' do
     its(:exit_status) { is_expected.to eq 0 }
     its(:stdout) { is_expected.not_to match %r{agent.* 0\.1\.2} }
   end
+
+  context 'install package via extra_index' do
+    it 'works with no errors' do
+      pp = <<-PUPPET
+      class { 'python':
+        version => '3',
+        dev     => 'present',
+      }
+
+      python::pyvenv { '/opt/test-venv':
+        ensure      => 'present',
+        systempkgs  => false,
+        mode        => '0755',
+        pip_version => '<= 20.3.4',
+      }
+
+      python::pip { 'agent package via extra_index':
+        virtualenv  => '/opt/test-venv',
+        pkgname     => 'agent',
+        index       => 'invalid',
+        extra_index => 'https://pypi.org/simple',
+        ensure      => '0.1.2',
+      }
+      PUPPET
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
+
+  describe command('/opt/test-venv/bin/pip list') do
+    its(:exit_status) { is_expected.to eq 0 }
+    its(:stdout) { is_expected.to match %r{agent.* 0\.1\.2} }
+  end
+  # rubocop:enable RSpec/RepeatedExampleGroupBody
   # rubocop:enable RSpec/RepeatedExampleGroupDescription
 end

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -76,7 +76,7 @@ describe 'python::pip', type: :define do
       context 'adds proxy to install command if proxy set' do
         let(:params) { { proxy: 'http://my.proxy:3128' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install   --proxy=http://my.proxy:3128  rpyc') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install    --proxy=http://my.proxy:3128  rpyc') }
       end
     end
 
@@ -90,7 +90,21 @@ describe 'python::pip', type: :define do
       context 'adds index to install command if index set' do
         let(:params) { { index: 'http://www.example.com/simple/' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install  --index-url=http://www.example.com/simple/   rpyc') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install  --index-url=http://www.example.com/simple/    rpyc') }
+      end
+    end
+
+    describe 'extra_index as' do
+      context 'defaults to empty' do
+        let(:params) { {} }
+
+        it { is_expected.not_to contain_exec('pip_install_rpyc').with_command(%r{--extra-index-url}) }
+      end
+
+      context 'adds extra_index to install command if extra_index set' do
+        let(:params) { { extra_index: 'http://www.example.com/extra/simple/' } }
+
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install   --extra-index-url=http://www.example.com/extra/simple/   rpyc') }
       end
     end
 
@@ -107,7 +121,7 @@ describe 'python::pip', type: :define do
       context 'adds install_args to install command if install_args set' do
         let(:params) { { install_args: '--pre' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install --pre    rpyc') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install --pre     rpyc') }
       end
     end
 
@@ -171,13 +185,13 @@ describe 'python::pip', type: :define do
       context 'suceeds with no extras' do
         let(:params) { {} }
 
-        it { is_expected.to contain_exec('pip_install_requests').with_command('pip --log /tmp/pip.log install     requests') }
+        it { is_expected.to contain_exec('pip_install_requests').with_command('pip --log /tmp/pip.log install      requests') }
       end
 
       context 'succeeds with extras' do
         let(:params) { { extras: ['security'] } }
 
-        it { is_expected.to contain_exec('pip_install_requests').with_command('pip --log /tmp/pip.log install     requests[security]') }
+        it { is_expected.to contain_exec('pip_install_requests').with_command('pip --log /tmp/pip.log install      requests[security]') }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

Add extra_index parameter to python::pip, corresponding to the pip command line option --extra-index-url, allowing packages to be installed from a local repository while dependencies are pulled from pypi.

#### This Pull Request (PR) fixes the following issues

None.