### PR TITLE
cleanup acceptance tests

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -20,7 +20,6 @@ describe 'python class' do
       pp = <<-EOS
       class { 'python':
         ensure     => 'present',
-        version    => '3',
         pip        => 'present',
         dev        => 'present',
         venv       => 'present',

--- a/spec/acceptance/pip_spec.rb
+++ b/spec/acceptance/pip_spec.rb
@@ -7,8 +7,7 @@ describe 'python::pip defined resource' do
     it 'works with no errors' do
       pp = <<-PUPPET
       class { 'python':
-        version => '3',
-        dev     => 'present',
+        dev => 'present',
       }
 
       python::pyvenv { '/opt/test-venv':
@@ -41,8 +40,7 @@ describe 'python::pip defined resource' do
     it 'works with no errors' do
       pp = <<-PUPPET
       class { 'python':
-        version => '3',
-        dev     => 'present',
+        dev => 'present',
       }
 
       python::pyvenv { '/opt/test-venv':
@@ -80,8 +78,7 @@ describe 'python::pip defined resource' do
     it 'works with no errors' do
       pp = <<-PUPPET
       class { 'python':
-        version => '3',
-        dev     => 'present',
+        dev => 'present',
       }
 
       python::pyvenv { '/opt/test-venv':

--- a/spec/acceptance/pyvenv_spec.rb
+++ b/spec/acceptance/pyvenv_spec.rb
@@ -8,9 +8,8 @@ describe 'python::pyvenv defined resource with python 3' do
     it 'works with no errors' do
       pp = <<-PUPPET
       class { 'python':
-        version => '3',
-        dev     => 'present',
-        venv    => 'present',
+        dev  => 'present',
+        venv => 'present',
       }
       user { 'agent':
         ensure         => 'present',
@@ -41,9 +40,8 @@ describe 'python::pyvenv defined resource with python 3' do
     it 'works with no errors' do
       pp = <<-PUPPET
       class { 'python':
-        version => '3',
-        dev     => 'present',
-        venv    => 'present',
+        dev  => 'present',
+        venv => 'present',
       }
       user { 'agent':
         ensure         => 'present',
@@ -82,9 +80,8 @@ describe 'python::pyvenv defined resource with python 3' do
     it 'works with no errors' do
       pp = <<-PUPPET
       class { 'python':
-        version => '3',
-        dev     => 'present',
-        venv    => 'present',
+        dev  => 'present',
+        venv => 'present',
       }
       user { 'agent':
         ensure         => 'present',
@@ -120,9 +117,8 @@ describe 'python::pyvenv defined resource with python 3' do
     it 'works with no errors' do
       pp = <<-PUPPET
       class { 'python':
-        version => '3',
-        dev     => 'present',
-        venv    => 'present',
+        dev  => 'present',
+        venv => 'present',
       }
       user { 'agent':
         ensure         => 'present',
@@ -158,9 +154,8 @@ describe 'python::pyvenv defined resource with python 3' do
     it 'works with no errors' do
       pp = <<-PUPPET
       class { 'python':
-        version => '3',
-        dev     => 'present',
-        venv    => 'present',
+        dev  => 'present',
+        venv => 'present',
       }
       user { 'agent':
         ensure         => 'present',


### PR DESCRIPTION
this module effectivly only supports python 3, which is also the default in the init.pp. we do not need to specify it in the tests.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
