### PR TITLE
Fix pip installation on Gentoo

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -213,42 +213,33 @@ class python::install {
       }
 
       if String($python::version) =~ /^python3/ {
-        $pip_category = undef
         $pip_package  = "${python}-pip"
         $pip_provider = $python.regsubst(/^.*python3\.?/,'pip3.').regsubst(/\.$/,'')
       } elsif ($facts['os']['family'] == 'RedHat') and (versioncmp($facts['os']['release']['major'], '8') >= 0) {
-        $pip_category = undef
         $pip_package  = 'python3-pip'
         $pip_provider = pip3
       } elsif ($facts['os']['family'] == 'RedHat') and (versioncmp($facts['os']['release']['major'], '7') >= 0) {
-        $pip_category = undef
         $pip_package  = 'python2-pip'
         $pip_provider = pip2
       } elsif $facts['os']['family'] == 'FreeBSD' {
-        $pip_category = undef
         $pip_package  = "py${python::version}-pip"
         $pip_provider = 'pip'
       } elsif $facts['os']['family'] == 'Gentoo' {
-        $pip_category = 'dev-python'
-        $pip_package  = 'pip'
+        $pip_package  = 'dev-python/pip'
         $pip_provider = 'pip'
       } elsif ($facts['os']['name'] == 'Ubuntu') and (versioncmp($facts['os']['release']['major'], '20.04') >= 0) {
-        $pip_category = undef
         $pip_package  = 'python3-pip'
         $pip_provider = 'pip3'
       } elsif ($facts['os']['name'] == 'Debian') and (versioncmp($facts['os']['release']['major'], '11') >= 0) {
-        $pip_category = undef
         $pip_package  = 'python3-pip'
         $pip_provider = 'pip3'
       } else {
-        $pip_category = undef
         $pip_package  = 'python-pip'
         $pip_provider = 'pip'
       }
 
       Package <| title == 'pip' |> {
-        name     => $pip_package,
-        category => $pip_category,
+        name => $pip_package,
       }
     }
   }

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -489,7 +489,7 @@ describe 'python' do
           it { is_expected.to contain_class('python::install') }
           # Base debian packages.
           it { is_expected.to contain_package('python') }
-          it { is_expected.to contain_package('pip').with('category' => 'dev-python') }
+          it { is_expected.to contain_package('pip').with('name' => 'dev-python/pip') }
           # Python::Dev
           it { is_expected.not_to contain_package('python-dev') }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The 'pip' package name is ambiguous on Gentoo, with options 'app-misc/pip' and 'dev-python/pip', resulting in the following error during installation:

> Error: /Stage[main]/Python::Install/Package[pip]: Could not evaluate: More than one package with the specified name [pip], please use the category parameter to disambiguate

The error message directs us to use the `category` parameter, which this module already did; however, `category` is a "read-only parameter set by the package" [1].

The correct way to disambiguate this package is to use the full package name, 'dev-python/pip'.

[1] https://www.puppet.com/docs/puppet/7/types/package.html#package-attribute-category

#### This Pull Request (PR) fixes the following issues
n/a
