### PR TITLE
Rocky does not have a separate venv package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,7 +35,7 @@ class python::install {
     ##
     ## CentOS has no extra package for venv
     ##
-    unless $facts['os']['name'] == 'CentOS' {
+    unless $facts['os']['name'] in ['CentOS', 'Rocky'] {
       package { 'python-venv':
         ensure  => $python::venv,
         name    => "${python}-venv",

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -23,7 +23,7 @@ describe 'python' do
           it { is_expected.to contain_package('pip') }
         end
 
-        if %w[Archlinux CentOS].include?(facts[:os]['name'])
+        if %w[Archlinux CentOS Rocky].include?(facts[:os]['name'])
           it { is_expected.not_to contain_package('python-venv') }
         else
           it { is_expected.to contain_package('python-venv') }
@@ -58,7 +58,7 @@ describe 'python' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_package('pip').with(ensure: 'present') }
 
-        it { is_expected.to contain_package('python-venv').with(ensure: 'present') } unless facts[:os]['name'] == 'CentOS'
+        it { is_expected.to contain_package('python-venv').with(ensure: 'present') } unless %w[CentOS Rocky].include?(facts[:os]['name'])
       end
 
       case facts[:os]['family']


### PR DESCRIPTION
This PR fixes the `ensure => present` on the python-venv package on rocky linux. It does, like CentOS, not have a seperate venv package.