### PR TITLE
Allow to skip management of python dev package

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -79,6 +79,7 @@ The following parameters are available in the `python` class:
 * [`umask`](#-python--umask)
 * [`manage_gunicorn`](#-python--manage_gunicorn)
 * [`manage_python_package`](#-python--manage_python_package)
+* [`manage_dev_package`](#-python--manage_dev_package)
 * [`manage_venv_package`](#-python--manage_venv_package)
 * [`manage_pip_package`](#-python--manage_pip_package)
 * [`venv`](#-python--venv)
@@ -189,6 +190,14 @@ Default value: `true`
 Data type: `Boolean`
 
 manage the state for package python
+
+Default value: `true`
+
+##### <a name="-python--manage_dev_package"></a>`manage_dev_package`
+
+Data type: `Boolean`
+
+manage the state of the python development package
 
 Default value: `true`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@
 # @param umask The default umask for invoked exec calls.
 # @param manage_gunicorn manage the state for package gunicorn
 # @param manage_python_package manage the state for package python
+# @param manage_dev_package manage the state of the python development package
 # @param manage_venv_package manage the state for package venv
 # @param manage_pip_package manage the state for package pip
 #
@@ -45,6 +46,7 @@ class python (
   Python::Package::Ensure    $gunicorn                    = 'absent',
   Boolean                    $manage_gunicorn             = true,
   Boolean                    $manage_python_package       = true,
+  Boolean                    $manage_dev_package          = true,
   Boolean                    $manage_venv_package         = $python::params::manage_venv_package,
   Boolean                    $manage_pip_package          = $python::params::manage_pip_package,
   String[1]                  $gunicorn_package_name       = $python::params::gunicorn_package_name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -53,7 +53,7 @@ class python::install {
         }
       }
 
-      if $pythondev {
+      if $python::manage_dev_package and $pythondev {
         package { 'python-dev':
           ensure => $python::dev,
           name   => $pythondev,
@@ -179,7 +179,7 @@ class python::install {
             }
           }
 
-          if $pythondev {
+          if $python::manage_dev_package and $pythondev {
             package { 'python-dev':
               ensure   => $python::dev,
               name     => $pythondev,
@@ -196,7 +196,7 @@ class python::install {
             }
           }
 
-          if $pythondev {
+          if $python::manage_dev_package and $pythondev {
             package { 'python-dev':
               ensure => $python::dev,
               name   => $pythondev,

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -34,6 +34,7 @@ describe 'python' do
         let :params do
           {
             manage_python_package: false,
+            manage_dev_package: false,
             manage_pip_package: false,
             manage_venv_package: false
           }
@@ -41,6 +42,7 @@ describe 'python' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.not_to contain_package('python') }
+        it { is_expected.not_to contain_package('python-dev') }
         it { is_expected.not_to contain_package('pip') }
         it { is_expected.not_to contain_package('python-venv') }
       end


### PR DESCRIPTION
Just like we can skip managing the pip and venv packages, allow to opt-out of managing the dev package.

Enforcing a state of these packages sometimes cause trouble if the user of the module does not care about them but they get installed as another package dependency (e.g. syslog-ng-mod-python depends on python-venv, by default python-venv is ensured absent, so on each run Puppet wants to install syslog-ng-mod-python (which install python-venv as a dependency) or remove python-venv (which remove syslog-ng-mod-python as a dependency)).  This can be avoided using the corresponding `manage_XXX_package` paramater, but `manage_dev_package` was missing.

This is part 1/3 of #668
