### PR TITLE
Use the wheel group by default on FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,8 +16,9 @@ class python::params {
   }
 
   $group = $facts['os']['family'] ? {
-    'AIX' => 'system',
-    default => 'root'
+    'AIX'     => 'system',
+    'FreeBSD' => 'wheel',
+    default   => 'root'
   }
 
   $pip_lookup_path = $facts['os']['family'] ? {


### PR DESCRIPTION
FreeBSD does not have a 'root' group.  System files owned by the 'root'
user belong to the 'wheel' group, so use that group by default.

This allow to use python::pip without the need to explicitly set the
`group` parameter to avoid the error:

> Error: Could not execute posix command: Invalid group: root
