### PR TITLE
Bump puppet-epel to allow 5.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
     },
     {
       "name": "puppet/epel",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Update puppet-epel to allow installing the latest v5.x

#### This Pull Request (PR) fixes the following issues

Fixes #671 