### PR TITLE
Add OracleLinux/AlmaLinux/Rocky support

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,7 +35,7 @@ class python::install {
     ##
     ## CentOS has no extra package for venv
     ##
-    unless $facts['os']['name'] == 'CentOS' {
+    unless $facts['os']['family'] == 'RedHat' {
       package { 'python-venv':
         ensure  => $python::venv,
         name    => "${python}-venv",

--- a/metadata.json
+++ b/metadata.json
@@ -21,6 +21,13 @@
       ]
     },
     {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
@@ -50,6 +57,27 @@
       "operatingsystemrelease": [
         "18.04",
         "20.04"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -23,7 +23,7 @@ describe 'python' do
           it { is_expected.to contain_package('pip') }
         end
 
-        if %w[Archlinux CentOS].include?(facts[:os]['name'])
+        if %w[Archlinux RedHat].include?(facts[:os]['family'])
           it { is_expected.not_to contain_package('python-venv') }
         else
           it { is_expected.to contain_package('python-venv') }
@@ -60,7 +60,7 @@ describe 'python' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_package('pip').with(ensure: 'present') }
 
-        it { is_expected.to contain_package('python-venv').with(ensure: 'present') } unless facts[:os]['name'] == 'CentOS'
+        it { is_expected.to contain_package('python-venv').with(ensure: 'present') } unless facts[:os]['family'] == 'RedHat'
       end
 
       case facts[:os]['family']


### PR DESCRIPTION
#### Pull Request (PR) description

Newer(8+) RedHat family OSes do not package python-venv as it is built in to the versions of Python they ship

#### This Pull Request (PR) fixes the following issues

n/a
