### PR TITLE
Add python_path to pyvenv class

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -913,6 +913,7 @@ The following parameters are available in the `python::pyvenv` defined type:
 * [`path`](#-python--pyvenv--path)
 * [`environment`](#-python--pyvenv--environment)
 * [`prompt`](#-python--pyvenv--prompt)
+* [`python_path`](#-python--pyvenv--python_path)
 * [`pip_version`](#-python--pyvenv--pip_version)
 
 ##### <a name="-python--pyvenv--ensure"></a>`ensure`
@@ -992,6 +993,14 @@ Default value: `[]`
 Data type: `Optional[String[1]]`
 
 Optionally specify the virtualenv prompt (python >= 3.6)
+
+Default value: `undef`
+
+##### <a name="-python--pyvenv--python_path"></a>`python_path`
+
+Data type: `Optional[String[1]]`
+
+Optionally specify python path for creation of virtualenv
 
 Default value: `undef`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -998,7 +998,7 @@ Default value: `undef`
 
 ##### <a name="-python--pyvenv--python_path"></a>`python_path`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Optionally specify python path for creation of virtualenv
 

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -11,6 +11,7 @@
 # @param path Specifies the PATH variable.
 # @param environment Optionally specify environment variables for pyvenv
 # @param prompt Optionally specify the virtualenv prompt (python >= 3.6)
+# @param python_path Optionally specify python path for creation of virtualenv
 #
 # @example
 #   python::pyvenv { '/var/www/project1' :
@@ -34,6 +35,7 @@ define python::pyvenv (
   Array                       $environment = [],
   Optional[String[1]]         $prompt      = undef,
   Python::Venv::PipVersion    $pip_version = 'latest',
+  Optional[String[1]]         $python_path = undef,
 ) {
   include python
 
@@ -46,11 +48,17 @@ define python::pyvenv (
     $python_version_parts      = split($python_version, '[.]')
     $normalized_python_version = sprintf('%s.%s', $python_version_parts[0], $python_version_parts[1])
 
+    $local_exec_prefix = $python_path ? {
+      undef   => $python::exec_prefix,
+      default => $python_path,
+    }
     # pyvenv is deprecated since 3.6 and will be removed in 3.8
-    if versioncmp($normalized_python_version, '3.6') >=0 {
-      $virtualenv_cmd = "${python::exec_prefix}python${normalized_python_version} -m venv"
+    if $python_path != undef {
+      $virtualenv_cmd = "${python_path} -m venv"
+    } elsif versioncmp($normalized_python_version, '3.6') >=0 {
+      $virtualenv_cmd = "${local_exec_prefix}python${normalized_python_version} -m venv"
     } else {
-      $virtualenv_cmd = "${python::exec_prefix}pyvenv-${normalized_python_version}"
+      $virtualenv_cmd = "${local_exec_prefix}pyvenv-${normalized_python_version}"
     }
 
     $_path = $python::provider ? {

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -35,7 +35,7 @@ define python::pyvenv (
   Array                       $environment = [],
   Optional[String[1]]         $prompt      = undef,
   Python::Venv::PipVersion    $pip_version = 'latest',
-  Optional[String[1]]         $python_path = undef,
+  Optional[Stdlib::Absolutepath] $python_path = undef,
 ) {
   include python
 

--- a/spec/acceptance/pyvenv_spec.rb
+++ b/spec/acceptance/pyvenv_spec.rb
@@ -196,7 +196,7 @@ describe 'python::pyvenv defined resource with python 3' do
   context 'with versioned minimal python::pip and without systempkgs using custom python path' do
     it 'works with no errors' do
       pp = <<-PUPPET
-      
+
       class { 'python':
         dev  => 'present',
         venv => 'present',

--- a/spec/acceptance/pyvenv_spec.rb
+++ b/spec/acceptance/pyvenv_spec.rb
@@ -192,4 +192,53 @@ describe 'python::pyvenv defined resource with python 3' do
       its(:stdout) { is_expected.to match %r{agent.* 0\.1\.2} }
     end
   end
+
+  context 'with versioned minimal python::pip and without systempkgs using custom python path' do
+    it 'works with no errors' do
+      pp = <<-PUPPET
+      
+      class { 'python':
+        dev  => 'present',
+        venv => 'present',
+      }
+      file { '/usr/bin/mycustompython':
+        ensure => link,
+        target => '/usr/bin/python',
+      }
+      user { 'agent':
+        ensure         => 'present',
+        managehome     => true,
+        home           => '/opt/agent',
+      }
+      group { 'agent':
+        ensure => 'present',
+        system => true,
+      }
+      python::pyvenv { '/opt/agent/venv':
+        ensure      => 'present',
+        systempkgs  => false,
+        owner       => 'agent',
+        group       => 'agent',
+        mode        => '0755',
+        pip_version => '<= 20.3.4',
+        python_path => '/usr/bin/mycustompython',
+      }
+      python::pip { 'agent' :
+        ensure     => '0.1.2',
+        virtualenv => '/opt/agent/venv',
+        owner      => 'agent',
+        group      => 'agent',
+      }
+      PUPPET
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe command('/opt/agent/venv/bin/pip list') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match %r{agent.* 0\.1\.2} }
+    end
+  end
 end


### PR DESCRIPTION
Issue #685

- Add: `python_path` variable to `python::pyvenv`

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add a custom path for python to the pyvenv module in order to use `pyenv` managed python installations

#### This Pull Request (PR) fixes the following issues
Fixes #685 
