### PR TITLE
Correct FreeBSD Python package name 

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -222,7 +222,7 @@ class python::install {
         $pip_package  = 'python2-pip'
         $pip_provider = pip2
       } elsif $facts['os']['family'] == 'FreeBSD' {
-        $pip_package  = "py${python::version}-pip"
+        $pip_package = sprintf( "py%s-pip", regsubst($python::version, '([0-9])\\.([0-9]+)', '\\1\\2') )
         $pip_provider = 'pip'
       } elsif $facts['os']['family'] == 'Gentoo' {
         $pip_package  = 'dev-python/pip'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,6 +40,7 @@ class python::params {
   }
   $manage_venv_package = $facts['os']['family'] ? {
     'Archlinux' => false,
+    'FreeBSD'   => false,
     default     => true,
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

When trying to install Puppetboard I ran into this module trying to install virtualenv (doesn't exist as a package, only a port) and `py3.9-pip` (correct name is `py39-pip`). 

Replace out the `.` in the version name. I did not test this extensively, just enough to get it to compile and install the right package for puppetboard. The origination of of the module doesn't seem to allow an easy way to get a default version based on OS and pass it down to python, pip, etc.

Feedback welcome.
