### PR TITLE
Fix python::pip - use valid, but highly unlikely package version

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -219,7 +219,7 @@ define python::pip (
         # more than one line with paretheses.
         $latest_version = join([
             "${pip_install} ${legacy_resolver} ${pypi_index} ${pypi_extra_index} ${proxy_flag}",
-            " ${install_args} ${install_editable} ${real_pkgname}==notreallyaversion 2>&1",
+            " ${install_args} ${install_editable} '${real_pkgname}==9!0dev0+x' 2>&1",
             " | sed -nE 's/.*\\(from versions: (.*, )*(.*)\\)/\\2/p'",
             ' | tr -d "[:space:]"',
         ])


### PR DESCRIPTION
This PR fixes `python::pip`'s `$latest_version` by replacing `notreallyaversion` with `9!0dev0+x`.

Fixes #695