### PR TITLE
simplify packages version detection

### DIFF
--- a/spec/acceptance/pip_spec.rb
+++ b/spec/acceptance/pip_spec.rb
@@ -74,6 +74,37 @@ describe 'python::pip defined resource' do
     its(:stdout) { is_expected.not_to match %r{agent.* 0\.1\.2} }
   end
 
+  context 'fails to install package with wrong version' do
+    it 'throws an error' do
+      pp = <<-PUPPET
+      class { 'python':
+        version => '3',
+        dev     => 'present',
+      }
+
+      python::pyvenv { '/opt/test-venv':
+        ensure      => 'present',
+        systempkgs  => false,
+        mode        => '0755',
+        pip_version => '<= 20.3.4',
+      }
+
+      python::pip { 'agent package':
+        virtualenv => '/opt/test-venv',
+        pkgname    => 'agent',
+        ensure     => '0.1.33+2020-this_is_something-fun',
+      }
+      PUPPET
+
+      result = apply_manifest(pp, expect_failures: true)
+      expect(result.stderr).to contain(%r{returned 1 instead of one of})
+    end
+  end
+
+  describe command('/opt/test-venv/bin/pip show agent') do
+    its(:exit_status) { is_expected.to eq 1 }
+  end
+
   context 'install package via extra_index' do
     it 'works with no errors' do
       pp = <<-PUPPET


### PR DESCRIPTION
#### Pull Request (PR) description

Simplify package version detection. 
The current implementation is too clever, as it tries to replace the logic built in the package manager. 
At the same time we may not be able to chase changes in the package manager and we better hand this task over to the package manager. 
In other words, if the version number is wrong, the package manager will detect it and fail and we do not need to fail upfront. 


#### This Pull Request (PR) fixes the following issues

Use format:
Fixes #617
Replaces #618
