### PR TITLE
Fix bootstrapping `python::pyvenv` when Python is not installed

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -67,6 +67,7 @@ class { 'python' :
 
 The following parameters are available in the `python` class:
 
+* [`default_system_version`](#-python--default_system_version)
 * [`ensure`](#-python--ensure)
 * [`version`](#-python--version)
 * [`pip`](#-python--pip)
@@ -91,6 +92,12 @@ The following parameters are available in the `python` class:
 * [`rhscl_use_public_repository`](#-python--rhscl_use_public_repository)
 * [`anaconda_installer_url`](#-python--anaconda_installer_url)
 * [`anaconda_install_path`](#-python--anaconda_install_path)
+
+##### <a name="-python--default_system_version"></a>`default_system_version`
+
+Data type: `Python::Version`
+
+The default version of Python provided by the operating system. Only used as a fallback if Python is not installed yet to determine how to handle some actions that vary depending on the Python version used.
 
 ##### <a name="-python--ensure"></a>`ensure`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.11"

--- a/data/os/Archlinux.yaml
+++ b/data/os/Archlinux.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.13"

--- a/data/os/Debian/11.yaml
+++ b/data/os/Debian/11.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.9"

--- a/data/os/Debian/12.yaml
+++ b/data/os/Debian/12.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.11"

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.11"

--- a/data/os/Gentoo.yaml
+++ b/data/os/Gentoo.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.12"

--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.6"

--- a/data/os/RedHat/9.yaml
+++ b/data/os/RedHat/9.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.9"

--- a/data/os/Ubuntu/20.04.yaml
+++ b/data/os/Ubuntu/20.04.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.8"

--- a/data/os/Ubuntu/22.04.yaml
+++ b/data/os/Ubuntu/22.04.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.10"

--- a/data/os/Ubuntu/24.04.yaml
+++ b/data/os/Ubuntu/24.04.yaml
@@ -1,0 +1,1 @@
+python::default_system_version: "3.12"

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,23 @@
+---
+version: 5
+
+defaults:               # Used for any hierarchy level that omits these keys.
+  datadir: data         # This path is relative to hiera.yaml's directory.
+  data_hash: yaml_data  # Use the built-in YAML backend.
+
+hierarchy:
+  - name: "archicture"
+    paths:
+      - "architecture/%{facts.os.architecture}.yaml"
+      - "architecture/common.yaml"
+  - name: "osfamily/major release"
+    paths:
+      - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"   # Used to distinguish between Debian and Ubuntu
+      - "os/%{facts.os.family}/%{facts.os.release.major}.yaml" #
+      - "os/%{facts.os.family}/%{facts.kernelrelease}.yaml"    # Used for Solaris
+  - name: "osfamily"
+    paths:
+      - "os/%{facts.os.name}.yaml"
+      - "os/%{facts.os.family}.yaml"
+  - name: 'common'
+    path: 'common.yaml'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 # @summary Installs and manages python, python-dev and gunicorn.
 #
+# @param default_system_version The default version of Python provided by the operating system. Only used as a fallback if Python is not installed yet to determine how to handle some actions that vary depending on the Python version used.
 # @param ensure Desired installation state for the Python package.
 # @param version Python version to install. Beware that valid values for this differ a) by the provider you choose and b) by the osfamily/operatingsystem you are using.
 #  Allowed values:
@@ -38,6 +39,7 @@
 #   }
 #
 class python (
+  Python::Version            $default_system_version,
   Python::Package::Ensure    $ensure                      = 'present',
   Python::Version            $version                     = $facts['os']['family'] ? { 'Archlinux' => 'system', default => '3' },
   Python::Package::Ensure    $pip                         = 'present',

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -41,7 +41,7 @@ define python::pyvenv (
 
   if $ensure == 'present' {
     $python_version = $version ? {
-      'system' => $facts['python3_version'],
+      'system' => $facts['python3_version'].lest || { $python::default_system_version },
       default  => $version,
     }
 

--- a/spec/defines/pyvenv_spec.rb
+++ b/spec/defines/pyvenv_spec.rb
@@ -6,83 +6,94 @@ describe 'python::pyvenv', type: :define do
   on_supported_os.each do |os, facts|
     next if os == 'gentoo-3-x86_64'
 
+    let :title do
+      '/opt/env'
+    end
+
     context "on #{os}" do
-      let :facts do
-        # python3 is required to use pyvenv
-        facts.merge(
-          python3_version: '3.5.1'
-        )
-      end
-      let :title do
-        '/opt/env'
-      end
-
       context 'with default parameters' do
-        it { is_expected.to contain_file('/opt/env').that_requires('Class[python::install]') }
-        it { is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear   /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools') }
+        let :facts do
+          facts
+        end
+
+        it { is_expected.to compile }
       end
 
-      describe 'when ensure' do
-        context 'is absent' do
+      context 'with a specific python3 version' do
+        let :facts do
+          # python3 is required to use pyvenv
+          facts.merge(
+            python3_version: '3.5.1'
+          )
+        end
+
+        context 'with default parameters' do
+          it { is_expected.to contain_file('/opt/env').that_requires('Class[python::install]') }
+          it { is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear   /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools') }
+        end
+
+        describe 'when ensure' do
+          context 'is absent' do
+            let :params do
+              {
+                ensure: 'absent'
+              }
+            end
+
+            it {
+              expect(subject).to contain_file('/opt/env').with_ensure('absent').with_purge(true)
+            }
+          end
+        end
+      end
+
+      context "prompt on #{os} with python 3.6" do
+        let :facts do
+          # python 3.6 is required for venv and prompt
+          facts.merge(
+            python3_version: '3.6.1'
+          )
+        end
+        let :title do
+          '/opt/env'
+        end
+
+        context 'with prompt' do
           let :params do
             {
-              ensure: 'absent'
+              prompt: 'custom prompt',
             }
           end
 
           it {
-            expect(subject).to contain_file('/opt/env').with_ensure('absent').with_purge(true)
+            is_expected.to contain_file('/opt/env').that_requires('Class[python::install]')
+            is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('python3.6 -m venv --clear  --prompt custom\\ prompt /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools')
           }
         end
       end
-    end
 
-    context "prompt on #{os} with python 3.6" do
-      let :facts do
-        # python 3.6 is required for venv and prompt
-        facts.merge(
-          python3_version: '3.6.1'
-        )
-      end
-      let :title do
-        '/opt/env'
-      end
-
-      context 'with prompt' do
-        let :params do
-          {
-            prompt: 'custom prompt',
-          }
+      context "prompt on #{os} with python 3.5" do
+        let :facts do
+          facts.merge(
+            python3_version: '3.5.1'
+          )
+        end
+        let :title do
+          '/opt/env'
         end
 
-        it {
-          is_expected.to contain_file('/opt/env').that_requires('Class[python::install]')
-          is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('python3.6 -m venv --clear  --prompt custom\\ prompt /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools')
-        }
-      end
-    end
+        context 'with prompt' do
+          let :params do
+            {
+              prompt: 'custom prompt',
+            }
+          end
 
-    context "prompt on #{os} with python 3.5" do
-      let :facts do
-        facts.merge(
-          python3_version: '3.5.1'
-        )
-      end
-      let :title do
-        '/opt/env'
-      end
-
-      context 'with prompt' do
-        let :params do
-          {
-            prompt: 'custom prompt',
+          it {
+            is_expected.to contain_file('/opt/env').that_requires('Class[python::install]')
+            is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear   /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools')
           }
         end
-
-        it {
-          is_expected.to contain_file('/opt/env').that_requires('Class[python::install]')
-          is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear   /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools')
-        }
       end
     end
   end


### PR DESCRIPTION
When python is not installed, a catalog with a `python::pyvenv` resource should compile and apply successfully.

Instead it currently cause a catalog compilation error:
```
   Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, The function 'split' was called with arguments it does not accept. It expects one of:
    (String str, String pattern)
      rejected: parameter 'str' expects a String value, got Undef
    (String str, Regexp pattern)
      rejected: parameter 'str' expects a String value, got Undef
    (String str, Type[Regexp] pattern)
      rejected: parameter 'str' expects a String value, got Undef
    (Sensitive[String] sensitive, String pattern)
      rejected: parameter 'sensitive' expects a Sensitive[String] value, got Undef
    (Sensitive[String] sensitive, Regexp pattern)
      rejected: parameter 'sensitive' expects a Sensitive[String] value, got Undef
    (Sensitive[String] sensitive, Type[Regexp] pattern)
      rejected: parameter 'sensitive' expects a Sensitive[String] value, got Undef (file: /etc/puppetlabs/code/environments/production/modules/python/manifests/pyvenv.pp, line: 48, column: 34) (file: /etc/puppetlabs/code/environments/production/modules/taiga/manifests/back/install.pp, line: 15) on node debian12-64-puppet7.example.com
```
