### PR TITLE
Replace legacy fact in gunicorn config templating

### DIFF
--- a/manifests/gunicorn.pp
+++ b/manifests/gunicorn.pp
@@ -55,6 +55,8 @@ define python::gunicorn (
   String[1]                             $template          = 'python/gunicorn.erb',
   Array                                 $args              = [],
 ) {
+  $processor_count = fact('processors.count')
+
   if $manage_config_dir {
     file { $config_dir:
       ensure => directory,

--- a/spec/defines/gunicorn_spec.rb
+++ b/spec/defines/gunicorn_spec.rb
@@ -13,8 +13,11 @@ describe 'python::gunicorn', type: :define do
         context 'configures test app with default parameter values' do
           let(:params) { { dir: '/srv/testapp' } }
           let(:expected_workers) do
+            # manifests/gunicorn.pp
+            processor_count = facts.dig(:processors, 'count')
+
             # templates/gunicorn.erb
-            (facts[:processorcount].to_i * 2) + 1
+            (processor_count.to_i * 2) + 1
           end
 
           it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--log-level=error}) }

--- a/spec/defines/gunicorn_spec.rb
+++ b/spec/defines/gunicorn_spec.rb
@@ -5,37 +5,28 @@ require 'spec_helper'
 describe 'python::gunicorn', type: :define do
   let(:title) { 'test-app' }
 
-  context 'on Debian OS' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        lsbdistcodename: 'squeeze',
-        osfamily: 'Debian',
-        operatingsystem: 'Debian',
-        operatingsystemrelease: '6',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        concat_basedir: '/dne'
-      }
-    end
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
 
-    describe 'test-app with default parameter values' do
-      context 'configures test app with default parameter values' do
-        let(:params) { { dir: '/srv/testapp' } }
+      describe 'test-app with default parameter values' do
+        context 'configures test app with default parameter values' do
+          let(:params) { { dir: '/srv/testapp' } }
 
-        it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--log-level=error}) }
-      end
+          it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--log-level=error}) }
+        end
 
-      context 'test-app with custom log level' do
-        let(:params) { { dir: '/srv/testapp', log_level: 'info' } }
+        context 'test-app with custom log level' do
+          let(:params) { { dir: '/srv/testapp', log_level: 'info' } }
 
-        it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--log-level=info}) }
-      end
+          it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--log-level=info}) }
+        end
 
-      context 'test-app with custom gunicorn preload arguments' do
-        let(:params) { { dir: '/srv/testapp', args: ['--preload'] } }
+        context 'test-app with custom gunicorn preload arguments' do
+          let(:params) { { dir: '/srv/testapp', args: ['--preload'] } }
 
-        it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--preload}) }
+          it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--preload}) }
+        end
       end
     end
   end

--- a/spec/defines/gunicorn_spec.rb
+++ b/spec/defines/gunicorn_spec.rb
@@ -12,8 +12,13 @@ describe 'python::gunicorn', type: :define do
       describe 'test-app with default parameter values' do
         context 'configures test app with default parameter values' do
           let(:params) { { dir: '/srv/testapp' } }
+          let(:expected_workers) do
+            # templates/gunicorn.erb
+            (facts[:processorcount].to_i * 2) + 1
+          end
 
           it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--log-level=error}) }
+          it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--workers=#{expected_workers}}) }
         end
 
         context 'test-app with custom log level' do
@@ -26,6 +31,12 @@ describe 'python::gunicorn', type: :define do
           let(:params) { { dir: '/srv/testapp', args: ['--preload'] } }
 
           it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--preload}) }
+        end
+
+        context 'test-app with custom workers count' do
+          let(:params) { { dir: '/srv/testapp', workers: 42 } }
+
+          it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(%r{--workers=#{params[:workers]}}) }
         end
       end
     end

--- a/templates/gunicorn.erb
+++ b/templates/gunicorn.erb
@@ -39,7 +39,7 @@ CONFIG = {
 <% if @workers -%>
     '--workers=<%= @workers %>',
 <% else -%>
-    '--workers=<%= @processorcount.to_i*2 + 1 %>',
+    '--workers=<%= @processor_count.to_i*2 + 1 %>',
 <% end -%>
     '--timeout=<%= @timeout %>',
 <% if @access_log_format -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

The template for gunicorn configuration was using the legacy fact `processorcount` in the formula for its default worker count. This changes the default to use the `processors.count` fact instead.

Test coverage specifically for `python::gunicorn` is extended to the regular supported os facts, instead of a single subset of Debian-ish facts.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
