### PR TITLE
Add section in README that simulates `python3 -m pip install pandas --user`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following code simulates
 python3 -m pip install pandas --user
 ```
 where pip installs packages to a user's default install directory --
-typically  ~/.local/ on Linux.
+typically  `~/.local/` on Linux.
 
 ```
 # Somewhat hackisly, install Python PIP module PANDAS for Oracle Cloud API queries.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ bundle exec rake strings:generate\[',,,,false,true']
 ### Install Python package to a user's default install directory
 
 The following code simulates
+
 ```shell
-python3 -m pip install pandas --user`
+python3 -m pip install pandas --user
 ```
 where pip installs packages to a user's default install directory --
 typically  ~/.local/ on Linux.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,34 @@ For class usage refer to the [Reference]("https://github.com/voxpupuli/puppet-py
 bundle exec rake strings:generate\[',,,,false,true']
 ```
 
+### Install Python package to a user's default install directory
+
+The following code simulates
+```shell
+python3 -m pip install pandas --user`
+```
+where pip installs packages to a user's default install directory --
+typically  ~/.local/ on Linux.
+
+```
+# Somewhat hackisly, install Python PIP module PANDAS for Oracle Cloud API queries.
+python::pyvenv { 'user_python_venv' :
+  ensure     => present,
+  version    => 'system',
+  systempkgs => true,
+  venv_dir   => '/home/example/.local',
+  owner      => 'example',
+  group      => 'example',
+  mode       => '0750',
+}
+
+python::pip { 'pandas':
+  virtualenv   => '/home/example/.local',
+  owner        => 'example',
+  group        => 'example',
+}
+```
+
 ### hiera configuration
 
 This module supports configuration through hiera. The following example

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ python3 -m pip install pandas --user
 where pip installs packages to a user's default install directory --
 typically  `~/.local/` on Linux.
 
-```
-# Somewhat hackisly, install Python PIP module PANDAS for Oracle Cloud API queries.
+```puppet
+# Somewhat hackishly, install Python PIP module PANDAS for Oracle Cloud API queries.
 python::pyvenv { 'user_python_venv' :
   ensure     => present,
   version    => 'system',

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ python::pyvenv { 'user_python_venv':
 }
 
 python::pip { 'pandas':
-  virtualenv   => '/home/example/.local',
-  owner        => 'example',
-  group        => 'example',
+  virtualenv => '/home/example/.local',
+  owner      => 'example',
+  group      => 'example',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ typically  `~/.local/` on Linux.
 
 ```puppet
 # Somewhat hackishly, install Python PIP module PANDAS for Oracle Cloud API queries.
-python::pyvenv { 'user_python_venv' :
+python::pyvenv { 'user_python_venv':
   ensure     => present,
   version    => 'system',
   systempkgs => true,


### PR DESCRIPTION
#### Pull Request (PR) description
The update shows how to simulate 
`python3 -m pip install pandas --user`
which will install the virtual environment and package 'pandas' for user in the user's default Python directory.
