### PR TITLE
Allow setting `python::version` in hiera to `Integer`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1212,5 +1212,14 @@ Alias of `Pattern[/^(<|>|<=|>=|==) [0-9]*(\.[0-9]+)*$/, /\Alatest\Z/]`
 
 Match all valid versions for python
 
-Alias of `Pattern[/\A(python)?[0-9](\.?[0-9])*/, /\Apypy\Z/, /\Asystem\Z/, /\Arh-python[0-9]{2}(?:-python)?\Z/]`
+Alias of
+
+```puppet
+Variant[Integer, Pattern[
+    /\A(python)?[0-9](\.?[0-9])*/,
+    /\Apypy\Z/,
+    /\Asystem\Z/,
+    /\Arh-python[0-9]{2}(?:-python)?\Z/
+  ]]
+```
 

--- a/types/version.pp
+++ b/types/version.pp
@@ -1,8 +1,10 @@
 # @summary Match all valid versions for python
 #
-type Python::Version = Pattern[
-  /\A(python)?[0-9](\.?[0-9])*/,
-  /\Apypy\Z/,
-  /\Asystem\Z/,
-  /\Arh-python[0-9]{2}(?:-python)?\Z/
+type Python::Version = Variant[Integer,
+  Pattern[
+    /\A(python)?[0-9](\.?[0-9])*/,
+    /\Apypy\Z/,
+    /\Asystem\Z/,
+    /\Arh-python[0-9]{2}(?:-python)?\Z/
+  ]
 ]


### PR DESCRIPTION

#### Pull Request (PR) description
Allow setting `python::version` in hiera to an integer value to match the `default` option in `install.pp`. This is required for FreeBSD.

#### This Pull Request (PR) fixes the following issues

Fixes #731
Semi related to #688 as the solution in this PR does not work when configured via hiera.

