### PR TITLE
Do not pass `--log` to `pip install`

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -181,7 +181,7 @@ define python::pip (
     default                                                                   => "'${url}#egg=${egg_name}'",
   }
 
-  $pip_install     = "${pip_env} --log ${log}/pip.log install"
+  $pip_install     = "${pip_env} install"
   $pip_common_args = "${pypi_index} ${pypi_extra_index} ${proxy_flag} ${install_editable} ${source}"
 
   # Explicit version out of VCS when PIP supported URL is provided

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -94,7 +94,7 @@ define python::pyvenv (
     }
 
     exec { "python_virtualenv_${venv_dir}":
-      command     => "${virtualenv_cmd} --clear ${system_pkgs_flag} ${prompt_arg} ${venv_dir} && ${pip_cmd} --log ${venv_dir}/pip.log install ${pip_upgrade} && ${pip_cmd} --log ${venv_dir}/pip.log install --upgrade setuptools",
+      command     => "${virtualenv_cmd} --clear ${system_pkgs_flag} ${prompt_arg} ${venv_dir} && ${pip_cmd} install ${pip_upgrade} && ${pip_cmd} install --upgrade setuptools",
       user        => $owner,
       creates     => "${venv_dir}/bin/activate",
       path        => $_path,

--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -98,7 +98,7 @@ define python::requirements (
 
   exec { "python_requirements${name}":
     provider    => shell,
-    command     => "${pip_env} --log ${log}/pip.log install ${proxy_flag} ${src_flag} -r ${requirements} ${extra_pip_args}",
+    command     => "${pip_env} install ${proxy_flag} ${src_flag} -r ${requirements} ${extra_pip_args}",
     refreshonly => !$forceupdate,
     timeout     => $timeout,
     cwd         => $cwd,

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -157,7 +157,7 @@ describe 'python' do
               it {
                 expect(subject).to contain_exec('python_virtualenv_/opt/env1').
                   with(
-                    command: 'python3.8 -m venv --clear   /opt/env1 && /opt/env1/bin/pip --log /opt/env1/pip.log install --upgrade pip && /opt/env1/bin/pip --log /opt/env1/pip.log install --upgrade setuptools',
+                    command: 'python3.8 -m venv --clear   /opt/env1 && /opt/env1/bin/pip install --upgrade pip && /opt/env1/bin/pip install --upgrade setuptools',
                     user: 'root',
                     creates: '/opt/env1/bin/activate',
                     path: [
@@ -177,7 +177,7 @@ describe 'python' do
               it {
                 expect(subject).to contain_exec('python_virtualenv_/opt/env2').
                   with(
-                    command: 'python3.8 -m venv --clear   /opt/env2 && /opt/env2/bin/pip --log /opt/env2/pip.log install --upgrade \'pip <= 20.3.4\' && /opt/env2/bin/pip --log /opt/env2/pip.log install --upgrade setuptools',
+                    command: 'python3.8 -m venv --clear   /opt/env2 && /opt/env2/bin/pip install --upgrade \'pip <= 20.3.4\' && /opt/env2/bin/pip install --upgrade setuptools',
                     user: 'root',
                     creates: '/opt/env2/bin/activate',
                     path: [

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -77,7 +77,7 @@ describe 'python::pip', type: :define do
       context 'adds proxy to install command if proxy set' do
         let(:params) { { proxy: 'http://my.proxy:3128' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install    --proxy=http://my.proxy:3128  rpyc') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip install    --proxy=http://my.proxy:3128  rpyc') }
       end
     end
 
@@ -91,7 +91,7 @@ describe 'python::pip', type: :define do
       context 'adds index to install command if index set' do
         let(:params) { { index: 'http://www.example.com/simple/' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install  --index-url=http://www.example.com/simple/    rpyc') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip install  --index-url=http://www.example.com/simple/    rpyc') }
       end
     end
 
@@ -105,7 +105,7 @@ describe 'python::pip', type: :define do
       context 'adds extra_index to install command if extra_index set' do
         let(:params) { { extra_index: 'http://www.example.com/extra/simple/' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install   --extra-index-url=http://www.example.com/extra/simple/   rpyc') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip install   --extra-index-url=http://www.example.com/extra/simple/   rpyc') }
       end
     end
 
@@ -122,7 +122,7 @@ describe 'python::pip', type: :define do
       context 'adds install_args to install command if install_args set' do
         let(:params) { { install_args: '--pre' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install --pre     rpyc') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip install --pre     rpyc') }
       end
     end
 
@@ -151,13 +151,13 @@ describe 'python::pip', type: :define do
       context 'supports v-prefixed version string' do
         let(:params) { { ensure: 'v1.7.0' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install      rpyc==v1.7.0') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip install      rpyc==v1.7.0') }
       end
 
       context 'supports version string without v-prefix' do
         let(:params) { { ensure: '1.7.0' } }
 
-        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip --log /tmp/pip.log install      rpyc==1.7.0') }
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command('pip install      rpyc==1.7.0') }
       end
     end
 
@@ -235,13 +235,13 @@ describe 'python::pip', type: :define do
       context 'suceeds with no extras' do
         let(:params) { {} }
 
-        it { is_expected.to contain_exec('pip_install_requests').with_command('pip --log /tmp/pip.log install      requests') }
+        it { is_expected.to contain_exec('pip_install_requests').with_command('pip install      requests') }
       end
 
       context 'succeeds with extras' do
         let(:params) { { extras: ['security'] } }
 
-        it { is_expected.to contain_exec('pip_install_requests').with_command('pip --log /tmp/pip.log install      requests[security]') }
+        it { is_expected.to contain_exec('pip_install_requests').with_command('pip install      requests[security]') }
       end
     end
   end

--- a/spec/defines/pyvenv_spec.rb
+++ b/spec/defines/pyvenv_spec.rb
@@ -29,7 +29,7 @@ describe 'python::pyvenv', type: :define do
 
         context 'with default parameters' do
           it { is_expected.to contain_file('/opt/env').that_requires('Class[python::install]') }
-          it { is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear   /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools') }
+          it { is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear   /opt/env && /opt/env/bin/pip install --upgrade pip && /opt/env/bin/pip install --upgrade setuptools') }
         end
 
         describe 'when ensure' do
@@ -67,7 +67,7 @@ describe 'python::pyvenv', type: :define do
 
           it {
             is_expected.to contain_file('/opt/env').that_requires('Class[python::install]')
-            is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('python3.6 -m venv --clear  --prompt custom\\ prompt /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools')
+            is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('python3.6 -m venv --clear  --prompt custom\\ prompt /opt/env && /opt/env/bin/pip install --upgrade pip && /opt/env/bin/pip install --upgrade setuptools')
           }
         end
       end
@@ -91,7 +91,7 @@ describe 'python::pyvenv', type: :define do
 
           it {
             is_expected.to contain_file('/opt/env').that_requires('Class[python::install]')
-            is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear   /opt/env && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade pip && /opt/env/bin/pip --log /opt/env/pip.log install --upgrade setuptools')
+            is_expected.to contain_exec('python_virtualenv_/opt/env').with_command('pyvenv-3.5 --clear   /opt/env && /opt/env/bin/pip install --upgrade pip && /opt/env/bin/pip install --upgrade setuptools')
           }
         end
       end


### PR DESCRIPTION
When passing a `--log` option to `pip install`, _verbose_ logging is
appended to the specified file, and the default logging captured by
puppet is _quitter_ than the default.

When an installation error occur, the quieter output does not contain
the reason for the failure, and inspection of the log file is necessary
to determine the reason of the error.  This is impractical in CI systems
where this file cannot be retrieved easily, and makes fixing regressions
harder.

On production systems, this log is also mostly useless since projects
dependencies versions are generally expected to be found in the
requirement file used for installation in order for deployments to be
reproducible.
